### PR TITLE
(feat) Begin virtual interface management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.bundle

--- a/lib/puppet/parser/functions/get_carp_ifconfig.rb
+++ b/lib/puppet/parser/functions/get_carp_ifconfig.rb
@@ -1,0 +1,18 @@
+require 'puppet_x/bsd/ifconfig_carp'
+
+module Puppet::Parser::Functions
+  newfunction(:get_carp_ifconfig,
+              :type => :rvalue) do |args|
+
+    config       = args.shift
+
+    c = {}
+    c[:vhid]    = config["vhid"] if config["vhid"]
+    c[:address] = config["address"] if config["address"]
+    c[:advbase] = config["advbase"] if config["advbase"]
+    c[:advskew] = config["advskew"] if config["advskew"]
+    c[:carpdev] = config["carpdev"] if config["carpdev"]
+
+    return PuppetX::BSD::Ifconfig_carp.new(c).content
+  end
+end

--- a/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
+++ b/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
@@ -4,14 +4,14 @@ module Puppet::Parser::Functions
   newfunction(:get_openbsd_hostname_if_content,
               :type => :rvalue) do |args|
 
-    config        = args.shift
+    config       = args.shift
 
     c = {}
+    c[:type]     = config["type"] if config["type"]
     c[:desc]     = config["description"] if config["description"]
     c[:values]   = config["values"] if config["values"]
     c[:options]  = config["options"] if config["options"]
 
-    hostname_if = PuppetX::BSD::Hostname_if.new(c)
-    return hostname_if.content
+    return PuppetX::BSD::Hostname_if.new(c).content
   end
 end

--- a/lib/puppet_x/bsd/ifconfig_carp.rb
+++ b/lib/puppet_x/bsd/ifconfig_carp.rb
@@ -1,0 +1,58 @@
+module PuppetX
+  module BSD
+    class Ifconfig_carp
+
+      attr_reader :content
+
+      def initialize(config)
+        @config = config
+        validate_config()
+      end
+
+      def validate_config
+
+        # compensate for puppet oddities
+        @config.reject!{ |k,v| k == :undef or v == :undef }
+
+        required_config_items = [
+          :vhid,
+          :address,
+        ]
+
+        # verify we have the required configuration items
+        required_config_items.each do |k,v|
+          unless @config.keys.include? k
+            raise ArgumentError, "#{k} is a required configuration item"
+          end
+        end
+
+        optional_config_items = [
+          :advbase,
+          :advskew,
+          :carpdev,
+        ]
+
+        @config.each do |k,v|
+          unless required_config_items.include? k or optional_config_items.include? k
+            raise ArgumentError, "unknown configuration item found: #{k}"
+          end
+        end
+
+      end
+
+      def content
+
+        data = []
+
+        data << @config[:address] if @config[:address]
+        data << 'vhid' << @config[:vhid] if @config[:vhid]
+        data << 'advbase' << @config[:advbase] if @config[:advbase]
+        data << 'advskew' << @config[:advskew] if @config[:advskew]
+        data << 'carpdev' << @config[:carpdev] if @config[:carpdev]
+
+        data.join(' ')
+      end
+
+    end
+  end
+end

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -54,7 +54,7 @@ class bsd::network (
           owner   => 'root',
           group   => '0',
           mode    => '0644',
-          content => inline_template("<%= @mygate.join(\"\n\") %>"),
+          content => inline_template("<%= @mygate.join(\"\n\") + \"\n\" %>"),
         }
       }
     }

--- a/manifests/network/carp.pp
+++ b/manifests/network/carp.pp
@@ -1,0 +1,17 @@
+class bsd::network::carp (
+  $allowed = true,
+  $preempt = false,
+) {
+
+  if $allowed == true {
+    sysctl::value { 'net.inet.carp.allow': value => 1 }
+  } else {
+    sysctl::value { 'net.inet.carp.allow': value => 0 }
+  }
+
+  if $preempt == true {
+    sysctl::value { 'net.inet.carp.preempt': value => 1 }
+  } else {
+    sysctl::value { 'net.inet.carp.preempt': value => 0 }
+  }
+}

--- a/manifests/network/gre.pp
+++ b/manifests/network/gre.pp
@@ -1,0 +1,10 @@
+class bsd::network::gre (
+  $allowed = true
+) {
+
+  if $allowed == true {
+    sysctl::value { 'net.inet.gre.allow': value => 1 }
+  } else {
+    sysctl::value { 'net.inet.gre.allow': value => 0 }
+  }
+}

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -7,20 +7,24 @@ define bsd::network::interface (
   $description   = undef,
   $values        = undef,
   $options       = undef,
-  #$commands      = undef,
 ) {
 
-  $if_name = $name
+  $if_name        = $name
   $interface_file = "/etc/hostname.${if_name}"
+  $if_type        = split($if_name, '\d+')
 
   $config = {
-    description    => $description,
-    values         => $values,
-    options        => $options,
+    type        => $if_type[0],
+    description => $description,
+    values      => $values,
+    options     => $options,
   }
 
+  debug("config: ${config}")
+
   $content = get_openbsd_hostname_if_content($config)
-  notice($content)
+
+  debug("content: ${content}")
 
   file { "/etc/hostname.${if_name}":
     content => $content,

--- a/manifests/network/interface/carp.pp
+++ b/manifests/network/interface/carp.pp
@@ -1,0 +1,29 @@
+define bsd::network::interface::carp (
+  $vhid,
+  $address,
+  $advbase     = undef,
+  $advskew     = undef,
+  $carpdev     = undef,
+  $description = undef,
+  $pass        = undef,
+) {
+
+  include bsd::network::carp
+
+  $if_name = $name
+
+  $config = {
+    address => $address,
+    vhid    => $vhid,
+    advbase => $advbase,
+    advskew => $advskew,
+    carpdev => $carpdev,
+  }
+
+  $carp_ifconfig = get_carp_ifconfig($config)
+
+  bsd::network::interface { $if_name:
+    description => $description,
+    values      => [$carp_ifconfig, 'up'],
+  }
+}

--- a/spec/unit/bsd/hostname_if_spec.rb
+++ b/spec/unit/bsd/hostname_if_spec.rb
@@ -229,5 +229,28 @@ describe 'PuppetX::BSD::Hostname_if' do
       PuppetX::BSD::Hostname_if.new(c).content.should match(/description "?Uplink"?/)
     end
 
+    it "should fail when the type is not a string" do
+      c = {
+        :type    => ['gif'],
+        :desc    => "I am a tunnel interface",
+        :values  => [
+          'up',
+        ]
+      }
+      expect { PuppetX::BSD::Hostname_if.new(c).content }.to raise_error
+    end
+
+    it "should support the gre interface type" do
+      c = {
+        :type    => 'gre',
+        :values  => [
+          '192.168.100.1 192.168.100.2 netmask 0xffffffff link0 up',
+          'tunnel 10.0.1.30 10.0.1.31',
+        ]
+      }
+      PuppetX::BSD::Hostname_if.new(c).content.should match(/192.168.100.1 192.168.100.2 netmask 0xffffffff link0 up/)
+      PuppetX::BSD::Hostname_if.new(c).content.should match(/tunnel 10.0.1.30 10.0.1.31/)
+    end
+
   end
 end

--- a/spec/unit/bsd/ifconfig_carp_spec.rb
+++ b/spec/unit/bsd/ifconfig_carp_spec.rb
@@ -1,0 +1,35 @@
+require 'puppet_x/bsd/ifconfig_carp'
+
+describe 'PuppetX::BSD::Ifconfig_carp' do
+
+  describe 'validation' do
+    it 'should fail if no config is supplied' do
+      c = {}
+      expect { PuppetX::BSD::Ifconfig_carp.new(c).content }.to raise_error
+    end
+  end
+
+  describe 'content' do
+    it 'should support a full example' do
+      c = {
+        :vhid    => '1',
+        :address => '10.0.0.1/24',
+        :advbase => '1',
+        :advskew => '0',
+        :carpdev => 'em0',
+      }
+      PuppetX::BSD::Ifconfig_carp.new(c).content.should match(/10.0.0.1\/24 vhid 1 advbase 1 advskew 0 carpdev em0/)
+    end
+
+    it 'should support a partial example' do
+      c = {
+        :vhid    => '1',
+        :address => '10.0.0.1/24',
+        :advbase => '1',
+        :advskew => '0',
+      }
+      PuppetX::BSD::Ifconfig_carp.new(c).content.should match(/10.0.0.1\/24 vhid 1 advbase 1 advskew 0/)
+    end
+  end
+
+end

--- a/tests/openbsd_basic.pp
+++ b/tests/openbsd_basic.pp
@@ -4,3 +4,8 @@ bsd::network::interface { 're0':
   values      => [ 'dhcp' ],
 }
 
+bsd::network::interface { 'em0':
+  description => 'Other interface',
+  values      => [ '10.0.0.1/24' ],
+}
+

--- a/tests/openbsd_carp.pp
+++ b/tests/openbsd_carp.pp
@@ -1,0 +1,5 @@
+bsd::network::interface::carp { "carp0":
+  vhid    => '1',
+  address => '10.0.0.1/24',
+  carpdev => 'em0',
+}

--- a/tests/openbsd_gre.pp
+++ b/tests/openbsd_gre.pp
@@ -1,0 +1,8 @@
+
+bsd::network::interface { 'gre0':
+  description => 'Tunnel interface',
+  values      => [
+    '172.16.0.1 172.16.0.2 netmask 0xffffffff link0 up',
+    'tunnel 1.2.3.4 5.6.7.8',
+  ],
+}


### PR DESCRIPTION
The following begins the work needed to flush out the virtual interfaces
that OpenBSD supports.

The first is, CARP.  We beign with a a wrapper class
bsd::network::interface::carp that has the needed paramaters.  We chew
on the inputs, before we spit out the ifconfig lines that we can pass to
the bsd::network::interface define to create the carp interface.  Works
like a charm.

Next up is the GRE interface managemnt.  We just piggy back on the
bsd::network::interface type here, and enable GRE when its needed.  I
expec that this interface will change in the future.  Ideally, pass in
the needed values similar to how the carp interface is done.  For now
this works, and is worth commiting.  Example has been inclued in the
tests/ directory.

Sysctl classes for enablement of each of the above has been included.

Add some basic testing for the above as well.
