### PR TITLE
Ensure a newline exists for each interface config

### DIFF
--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -27,7 +27,7 @@ define bsd::network::interface (
   debug("content: ${content}")
 
   file { "/etc/hostname.${if_name}":
-    content => $content,
+    content => inline_template('<%= content + "\n" %>'),
     notify  => Exec["netstart_${if_name}"],
   }
 


### PR DESCRIPTION
For some reason it seems that a newline is required for some of the
interfaces to come up when executed by /etc/netstart.  This code ensures
that the implementation of bsd::network::interface for openbsd will
append a newline to the config files.
