### PR TITLE
make the module future parser compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ their manifests.  The rest of the code here is simply to support the interface
 supplied by the manifests.  Implementing the functions directly is not advised,
 as the implementation may shift over time as the module requires.
 
+## Dependencies
+
+This module requires the 'ipaddress' ruby gem to be installed.
+
+```
+gem install ipaddress
+```
+
+or let Puppet take care:
+
+```Puppet
+package { 'ipaddress':
+  ensure   => 'present',
+  provider => 'gem',
+}
+```
+
 ## Network
 
 Network configuration is handled under the `bsd::network` name space.  Under

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -24,15 +24,15 @@ class bsd::network (
 
   # Options common to both FreeBSD and OpenBSD
   if $v4forwarding {
-    sysctl::value { 'net.inet.ip.forwarding': value => 1 }
+    sysctl::value { 'net.inet.ip.forwarding': value => '1' }
   } else {
-    sysctl::value { 'net.inet.ip.forwarding': value => 0 }
+    sysctl::value { 'net.inet.ip.forwarding': value => '0' }
   }
 
   if $v6forwarding {
-    sysctl::value { 'net.inet6.ip6.forwarding': value => 1 }
+    sysctl::value { 'net.inet6.ip6.forwarding': value => '1' }
   } else {
-    sysctl::value { 'net.inet6.ip6.forwarding': value => 0 }
+    sysctl::value { 'net.inet6.ip6.forwarding': value => '0' }
   }
 
   case $::osfamily {

--- a/manifests/network/carp.pp
+++ b/manifests/network/carp.pp
@@ -8,14 +8,14 @@ class bsd::network::carp (
 ) {
 
   if $allowed == true {
-    sysctl::value { 'net.inet.carp.allow': value => 1 }
+    sysctl::value { 'net.inet.carp.allow': value => '1' }
   } else {
-    sysctl::value { 'net.inet.carp.allow': value => 0 }
+    sysctl::value { 'net.inet.carp.allow': value => '0' }
   }
 
   if $preempt == true {
-    sysctl::value { 'net.inet.carp.preempt': value => 1 }
+    sysctl::value { 'net.inet.carp.preempt': value => '1' }
   } else {
-    sysctl::value { 'net.inet.carp.preempt': value => 0 }
+    sysctl::value { 'net.inet.carp.preempt': value => '0' }
   }
 }

--- a/manifests/network/gre.pp
+++ b/manifests/network/gre.pp
@@ -7,8 +7,8 @@ class bsd::network::gre (
 ) {
 
   if $allowed == true {
-    sysctl::value { 'net.inet.gre.allow': value => 1 }
+    sysctl::value { 'net.inet.gre.allow': value => '1' }
   } else {
-    sysctl::value { 'net.inet.gre.allow': value => 0 }
+    sysctl::value { 'net.inet.gre.allow': value => '0' }
   }
 }

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -24,7 +24,7 @@ define bsd::network::interface (
 
   $config = {
     name        => $name,
-    type        => $if_type[0],
+    'type'      => $if_type[0],
     description => $description,
     values      => $values,
     options     => $options,
@@ -37,9 +37,9 @@ define bsd::network::interface (
       $content = get_openbsd_hostname_if_content($config)
 
       if $state != undef {
-        $text = inline_template('<%= [content,state].join("\n") + "\n" %>')
+        $text = inline_template('<%= [@content,@state].join("\n") + "\n" %>')
       } else {
-        $text = inline_template('<%= content + "\n" %>')
+        $text = inline_template('<%= @content + "\n" %>')
       }
 
       file { "/etc/hostname.${if_name}":


### PR DESCRIPTION
And make a note into the README, about the ipaddress gem
as a requirement for the module to work.

travis build fails, but due to some unrelated error
with regard to tun configuration.

Tested with puppet 3.7.3, ruby-2.1.5, on OpenBSD 5.6 -current.
