### PR TITLE
Allow wifi interfaces configuration without requiring a network_key,

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ bsd::network::interface::wifi { 'athn0':
 #### bridge(4) interfaces
 ```Puppet
 bsd::network::interface::bridge { "bridge0":
-  interface => ['em0','em1],
+  interface => ['em0','em1'],
 }
 ```
 

--- a/lib/puppet/parser/functions/get_hostname_if_wifi.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_wifi.rb
@@ -8,7 +8,7 @@ module Puppet::Parser::Functions
 
     c = {}
     c[:network_name] = config["network_name"]
-    c[:network_key]  = config["network_key"]
+    c[:network_key]  = config["network_key"] if config["network_key"]
     c[:address]      = config["address"] if config["address"]
 
     return PuppetX::BSD::Hostname_if::Wifi.new(c).content

--- a/lib/puppet_x/bsd/hostname_if.rb
+++ b/lib/puppet_x/bsd/hostname_if.rb
@@ -156,9 +156,13 @@ module PuppetX
         lines = []
 
         supported_wifi_devices = [
-          'iwn',
           'ath',
           'athn',
+          'iwn',
+          'ral',
+          'rum',
+          'wi',
+          'wpi',
         ]
 
         supported_virtual_devices = [

--- a/lib/puppet_x/bsd/hostname_if/wifi.rb
+++ b/lib/puppet_x/bsd/hostname_if/wifi.rb
@@ -17,11 +17,11 @@ module PuppetX
           ::PuppetX::BSD::Util.normalize_config(@config)
           required_config_items = [
             :network_name,
-            :network_key,
           ]
 
           optional_config_items = [
             :address,
+            :network_key,
           ]
 
           ::PuppetX::BSD::Util.validate_config(
@@ -43,7 +43,9 @@ module PuppetX
           end
 
           data << ['nwid',@config[:network_name]].join(' ')
-          data << ['wpakey',@config[:network_key]].join(' ')
+          if @config[:network_key]
+            data << ['wpakey',@config[:network_key]].join(' ')
+          end
           data.join(' ')
         end
       end

--- a/manifests/network/interface/wifi.pp
+++ b/manifests/network/interface/wifi.pp
@@ -4,7 +4,7 @@
 #
 define bsd::network::interface::wifi (
   $network_name,
-  $network_key,
+  $network_key = undef,
   $address     = undef,
   $description = undef,
   $options     = undef,

--- a/spec/unit/bsd/hostname_if/wifi_spec.rb
+++ b/spec/unit/bsd/hostname_if/wifi_spec.rb
@@ -9,11 +9,11 @@ describe 'PuppetX::BSD::Hostname_if::Wifi' do
 
     it "should raise an error if missing arguments" do
       c = {
-        :network_name => 'myssid',
+        :network_key => 'topsecret',
       }
       expect {
         PuppetX::BSD::Hostname_if::Wifi.new(c).content
-      }.to raise_error(ArgumentError, /network_key.*required/)
+      }.to raise_error(ArgumentError, /network_name.*required/)
     end
 
     it "should raise an error if unknown arguments" do
@@ -29,7 +29,22 @@ describe 'PuppetX::BSD::Hostname_if::Wifi' do
   end
 
   describe 'content' do
-    it 'should support a full example' do
+    it 'should support a minimal example' do
+      c = {
+        :network_name => 'myssid',
+      }
+      expect(PuppetX::BSD::Hostname_if::Wifi.new(c).content).to match(/nwid myssid/)
+    end
+
+    it 'should support a minimal example with dhcp' do
+      c = {
+        :network_name => 'myssid',
+        :address      => ['dhcp'],
+      }
+      expect(PuppetX::BSD::Hostname_if::Wifi.new(c).content).to match(/dhcp nwid myssid/)
+    end
+
+    it 'should support a partial example' do
       c = {
         :network_name => 'myssid',
         :network_key => 'mykey',
@@ -37,7 +52,7 @@ describe 'PuppetX::BSD::Hostname_if::Wifi' do
       expect(PuppetX::BSD::Hostname_if::Wifi.new(c).content).to match(/nwid myssid wpakey mykey/)
     end
 
-    it 'should support a partial example' do
+    it 'should support a full example' do
       c = {
         :network_name => 'myssid',
         :network_key => 'mykey',

--- a/tests/openbsd_wifi.pp
+++ b/tests/openbsd_wifi.pp
@@ -1,0 +1,4 @@
+bsd::network::interface::wifi { 'wpi0':
+network_name => 'myssid',
+address      => [ 'dhcp', ],
+}

--- a/tests/openbsd_wifi.pp
+++ b/tests/openbsd_wifi.pp
@@ -1,4 +1,4 @@
 bsd::network::interface::wifi { 'wpi0':
-network_name => 'myssid',
-address      => [ 'dhcp', ],
+  network_name => 'myssid',
+  address      => [ 'dhcp', ]
 }


### PR DESCRIPTION
i.e. allow unencrypted wifi network configuration.

Update specs to reflect that change, add a few more wifi interfaces
I own and reorder them alphabetically. Add a little test.

Travis fails, due to :lint test in Rakefile,
removing that :lint test, tests are passing.

Don't know why it is failing, but puppet-lint also fails for me on
my local box with the same error on your master branch, without
me doing any changes :(

