### PR TITLE
The vehter remains unprocessed

### DIFF
--- a/lib/puppet_x/bsd/hostname_if.rb
+++ b/lib/puppet_x/bsd/hostname_if.rb
@@ -171,7 +171,7 @@ module PuppetX
           'pfsync',
           'trunk',
           'tun',
-          'vether',
+          #'vether',
           'vlan',
         ]
 

--- a/spec/defines/bsd_network_interface_spec.rb
+++ b/spec/defines/bsd_network_interface_spec.rb
@@ -23,10 +23,17 @@ describe "bsd::network::interface" do
 
     context "a vether device" do
       let(:title) { 'vether0' }
-      let(:params) { {:values => ['123..123.123.123/29', 'up'] } }
+      let(:params) { {
+        :values => [ '123.123.123.123/29',
+          '172.16.0.1/27',
+          'fc01::/7',
+          '2001:100:fed:beef::/64',
+          'up', ]
+        }
+      }
 
       it do
-        should contain_file('/etc/hostname.vether0').with_content(/123..123.123.123\/29\nup\n/)
+        should contain_file('/etc/hostname.vether0').with_content(/inet 123.123.123.123 255.255.255.248 NONE\ninet alias 172.16.0.1 255.255.255.224 NONE\ninet6 fc01:: 7\ninet6 alias 2001:100:fed:beef:: 64\nup\n/)
       end
     end
   end


### PR DESCRIPTION
Adding vether to the supported list means that the interface is
expected to have already been processed.  This is not quite so.  Until
we build a bsd::network::interface::vether define, we need not include
vether in the supported list, as implementing an interface with vether
does not require it.  The bsd::network::interface can be used directly.