### PR TITLE
With IPv4/IPv6 dual stack, the configurations have to be on separate lines.

### DIFF
--- a/lib/puppet_x/bsd/hostname_if/carp.rb
+++ b/lib/puppet_x/bsd/hostname_if/carp.rb
@@ -54,10 +54,8 @@ module PuppetX
             inet << i
           }
 
-          data = []
-          data << inet
-          data << carp_string()
-          data.join(' ')
+          inet.join(' ')
+          inet << carp_string()
         end
 
         def carp_string

--- a/lib/puppet_x/bsd/hostname_if/inet.rb
+++ b/lib/puppet_x/bsd/hostname_if/inet.rb
@@ -45,6 +45,7 @@ module PuppetX
                   line << 'alias' if @ip6set
                   line << ip.compressed
                   line << ip.prefix
+                  line << "\n"
                   @ip6set = true
                 elsif ip.ipv4?
                   line = ['inet']
@@ -52,6 +53,7 @@ module PuppetX
                   line << ip.address
                   line << ip.netmask
                   line << 'NONE'
+                  line << "\n"
                   @ipset = true
                 end
                 if line

--- a/lib/puppet_x/bsd/hostname_if/inet.rb
+++ b/lib/puppet_x/bsd/hostname_if/inet.rb
@@ -44,16 +44,14 @@ module PuppetX
                   line = ['inet6']
                   line << 'alias' if @ip6set
                   line << ip.compressed
-                  line << ip.prefix
-                  line << "\n"
+                  line << "#{ip.prefix}\n"
                   @ip6set = true
                 elsif ip.ipv4?
                   line = ['inet']
                   line << 'alias' if @ipset
                   line << ip.address
                   line << ip.netmask
-                  line << 'NONE'
-                  line << "\n"
+                  line << "NONE\n"
                   @ipset = true
                 end
                 if line

--- a/spec/defines/bsd_network_interface_carp_spec.rb
+++ b/spec/defines/bsd_network_interface_carp_spec.rb
@@ -17,7 +17,7 @@ describe "bsd::network::interface::carp" do
       }
       it do
         should contain_bsd__network__interface('carp0')
-        should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\nup\n/)
+        should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE\nvhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\nup\n/)
       end
     end
   end


### PR DESCRIPTION
Hi,
tested your issue38 branch, but the output was still IPv4 and IPv6 in one line.

Likely not for importing, just to show you:
Changes to lib/puppet_x/bsd/hostname_if/inet.rb fixes it for me, since the problem is not really with the WLAN options, but with the IPv4/IPv6 combination.

However, now many of the tests are failing, because lines get split up much more than before :(

I tried to fix at least started with carp, but however, I don't get them right.