### PR TITLE
Fix a failed rescue

### DIFF
--- a/lib/puppet_x/bsd/rc_conf.rb
+++ b/lib/puppet_x/bsd/rc_conf.rb
@@ -181,8 +181,8 @@ module PuppetX
             end
           end
         }
-      rescue
-        raise "addr is #{a} of class #{a.class}: #{e.message}"
+      rescue Exception => e
+        raise e.message
       end
     end
   end


### PR DESCRIPTION
This ensures that only in-scope variables are used as part of the
resecue.