### PR TITLE
Add test for a DHCP interface on FreeBSD

### DIFF
--- a/lib/puppet/provider/bsd_interface/ifconfig.rb
+++ b/lib/puppet/provider/bsd_interface/ifconfig.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:bsd_interface).provide(:ifconfig) do
   desc "Manage a BSD network interface state"
 
   confine :kernel => [:openbsd, :freebsd]
-  defaultfor :operatingsystem => :freebsd
+  defaultfor :kernel => [:openbsd, :freebsd]
   commands :ifconfig => '/sbin/ifconfig'
   #mk_resource_methods
 
@@ -13,12 +13,6 @@ Puppet::Type.type(:bsd_interface).provide(:ifconfig) do
 
   def state
     @state_output ||= get_state()
-
-    # Unsure how to test this, and the output from the command works well
-    # enough to determine the state.
-    #if output.exitstatus != 0
-    #  return 'absent'
-    #end
 
     case @state_output
     when /#{resource[:name]}:\sflags=.*<[^UP].*>/

--- a/lib/puppet_x/bsd/rc_conf.rb
+++ b/lib/puppet_x/bsd/rc_conf.rb
@@ -125,7 +125,9 @@ module PuppetX
         ipset    = false
 
         process_addresses(@address) {|addr|
-          if addr =~ /inet6 /
+          if addr =~ /DHCP/
+            addrs << addr
+          elsif addr =~ /inet6 /
             if ip6set
               aliases << addr
             else
@@ -147,9 +149,14 @@ module PuppetX
         # append the options to the first address
         if addrs.size > 0
           ifconfig[:addrs] = addrs
-          ifconfig[:addrs][0] = [ifconfig[:addrs][0],options_string()].join(' ')
+
+          if @options.size > 0
+            ifconfig[:addrs][0] = [ifconfig[:addrs][0],options_string()].join(' ')
+          end
         else
-          ifconfig[:addrs] = options_string()
+          if @options.size > 0
+            ifconfig[:addrs] = options_string()
+          end
         end
 
         if aliases.size > 0
@@ -161,8 +168,8 @@ module PuppetX
 
       def process_addresses(address=@address)
         address.each {|a|
-          if a =~ /^DHCP/
-            yield a
+          if a =~ /^(DHCP|dhcp)/
+            yield 'DHCP'
           else
             begin
               ip = IPAddress a

--- a/spec/unit/bsd/rc_conf_spec.rb
+++ b/spec/unit/bsd/rc_conf_spec.rb
@@ -22,6 +22,28 @@ describe 'PuppetX::BSD::Rc_conf' do
   end
 
   describe '#get_hash' do
+
+    context 'with a dynamic v4-only config' do
+
+      it "should return a valid config" do
+        hash = {
+          :re0 => {
+            :addrs => [
+              'DHCP',
+            ],
+          }
+        }
+
+        c = {
+          :name => 're0',
+          :address => [
+            'dhcp'
+          ]
+        }
+        expect(rc.new(c).get_hash).to eq(hash)
+      end
+    end
+
     context 'when a full config is supplied' do
       it 'should return the desired hash' do
 


### PR DESCRIPTION
Without this commit, 'dhcp' was not an allowed string in the values
array and would fail with a terrible error.  This adds a test for such a
case, and modifies the logic to work with interfaces configured by DHCP
on FreeBSD.