### PR TITLE
Add inet6 autoconf, additionally to rtsol

### DIFF
--- a/spec/unit/bsd/hostname_if/inet_spec.rb
+++ b/spec/unit/bsd/hostname_if/inet_spec.rb
@@ -16,14 +16,49 @@ describe 'PuppetX::BSD::Hostname_if::Inet' do
   end
 
   describe 'process' do
-    it "should yield the the dynamic addressing is specified for all AF" do
-      a = [
-        'dhcp',
-        'rtsol',
-      ]
-      expect {|b|
-        PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
-      }.to yield_successive_args('dhcp','rtsol')
+    context 'On OpenBSD 5.6' do
+      it "should yield the the dynamic addressing is specified for all AF with rtsol" do
+        a = [
+          'dhcp',
+          'rtsol',
+        ]
+        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
+        expect {|b|
+          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
+        }.to yield_successive_args('dhcp','rtsol')
+      end
+      it "should yield the the dynamic addressing is specified for all AF with inet6 autoconf" do
+        a = [
+          'dhcp',
+          'inet6 autoconf',
+        ]
+        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
+        expect {|b|
+          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
+        }.to yield_successive_args('dhcp','rtsol')
+      end
+    end
+    context 'On OpenBSD 5.7' do
+      it "should yield the the dynamic addressing is specified for all AF with rtsol" do
+        a = [
+          'dhcp',
+          'rtsol',
+        ]
+        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
+        expect {|b|
+          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
+        }.to yield_successive_args('dhcp','inet6 autoconf')
+      end
+      it "should yield the the dynamic addressing is specified for all AF with inet6 autoconf" do
+        a = [
+          'dhcp',
+          'inet6 autoconf',
+        ]
+        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
+        expect {|b|
+          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
+        }.to yield_successive_args('dhcp','inet6 autoconf')
+      end
     end
 
     it "should yield multiple addresses when specified" do

--- a/spec/unit/bsd/hostname_if_spec.rb
+++ b/spec/unit/bsd/hostname_if_spec.rb
@@ -85,14 +85,62 @@ describe 'PuppetX::BSD::Hostname_if' do
       expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
     end
 
-    it "should set the the dynamic property of the interface is specified for all AF" do
-      c = {
-        :values => [
-          'dhcp',
-          'rtsol',
-        ]
-      }
-      expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
+    context 'On OpenBSD 5.6' do
+      context 'with rtsol given for IPv6' do
+        it "should set the the dynamic property of the interface is specified for all AF keeping rtsol" do
+          c = {
+            :values => [
+              'dhcp',
+              'rtsol',
+            ]
+          }
+          expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^rtsol/)
+        end
+      end
+      context 'with inet6 autoconf given for IPv6' do
+        it "should set the the dynamic property of the interface is specified for all AF setting rtsol for inet6" do
+          c = {
+            :values => [
+              'dhcp',
+              'inet6 autoconf',
+            ]
+          }
+          expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^rtsol/)
+        end
+      end
+    end
+
+    context 'On OpenBSD 5.7' do
+      context 'with rtsol given for IPv6' do
+        it "should set the the dynamic property of the interface is specified for all AF setting inet6 autoconf for rtsol" do
+          c = {
+            :values => [
+              'dhcp',
+              'rtsol',
+            ]
+          }
+          expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^inet6 autoconf/)
+        end
+      end
+      context 'with inet6 autoconf given for IPv6' do
+        it "should set the the dynamic property of the interface is specified for all AF keeping" do
+          c = {
+            :values => [
+              'dhcp',
+              'inet6 autoconf',
+            ]
+          }
+          expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^dhcp/)
+          expect(PuppetX::BSD::Hostname_if.new(c).content).to match(/^inet6 autoconf/)
+        end
+      end
     end
 
     it "should set the primary interface address and prefix" do


### PR DESCRIPTION
I finally got around to look into that, but it's not really for merge yet, just to show off and discuss ;)

This allows to set 'inet6 autoconf' on one line, and get it propagated into hostname.if

however, I tried to add the versioncmp in there, to in case rtsol is given for 5.7 or higher, automatically replace with inet6 autoconf, and vice versa, if inet6 autoconf is given, for machines
with kernelversion < 5.7, return rtsol. However, on my 5.7... box, when I give rtsol, I end up with rtsol in hostname.if file, irregardless how I switch the comparisons... :(
I guess its just a stupid thing I get wrong, but don't see it right now. Do you have a cluebat maybe?

Cheers,
Sebastian


