### PR TITLE
Fix error when vlan id is passed as an integer

### DIFF
--- a/lib/puppet_x/bsd/rc_conf/vlan.rb
+++ b/lib/puppet_x/bsd/rc_conf/vlan.rb
@@ -21,7 +21,7 @@ module PuppetX
 
           # compensate for puppet oddities
           @config.reject!{ |k,v|
-            k == :undef or v == :undef or v.length == 0
+            k == :undef or v == :undef or v.to_s.length == 0
           }
 
           required_config_items = [
@@ -51,7 +51,7 @@ module PuppetX
         # Return an array of parsed values
         def values
           data = []
-          data << 'vlan ' + @config[:id]
+          data << 'vlan ' + @config[:id].to_s
           data << 'vlandev ' + @config[:device]
           data.flatten
         end

--- a/spec/unit/bsd/rc_conf/vlan_spec.rb
+++ b/spec/unit/bsd/rc_conf/vlan_spec.rb
@@ -63,6 +63,18 @@ describe 'PuppetX::BSD::Rc_conf::Vlan' do
           PuppetX::BSD::Rc_conf::Vlan.new(c).content
         }.to raise_error(ArgumentError, /unknown configuration item/)
       end
+
+      it "should not raise an error if the id is an integer" do
+        c = {
+          :id      => 1,
+          :device  => 'em0',
+          :address => '10.0.0.0/24',
+        }
+        expect {
+          PuppetX::BSD::Rc_conf::Vlan.new(c).content
+        }.not_to raise_error
+      end
+
     end
   end
 


### PR DESCRIPTION
Without this change, the code throws an "unknown method 'length'"
message due to the code treating the id as a string.

This work allows the id to be passed as an integer.