### PR TITLE
Standardize validation for hostname_if

### DIFF
--- a/lib/puppet_x/bsd/hostname_if/carp.rb
+++ b/lib/puppet_x/bsd/hostname_if/carp.rb
@@ -2,6 +2,7 @@
 #
 # Responsible for processing the carp(4) interfaces for hostname_if(5)
 #
+require 'puppet_x/bsd/util'
 require 'puppet_x/bsd/hostname_if/inet'
 
 module PuppetX
@@ -13,26 +14,13 @@ module PuppetX
 
         def initialize(config)
           @config = config
-          validate_config()
-        end
-
-        def validate_config
-
-          # compensate for puppet oddities
-          @config.reject!{ |k,v| k == :undef or v == :undef }
+          ::PuppetX::BSD::Util.normalize_config(@config)
 
           required_config_items = [
             :id,
             :address,
             :device,
           ]
-
-          # verify we have the required configuration items
-          required_config_items.each do |k,v|
-            unless @config.keys.include? k
-              raise ArgumentError, "#{k} is a required configuration item"
-            end
-          end
 
           optional_config_items = [
             :advbase,
@@ -41,11 +29,11 @@ module PuppetX
             :pass,
           ]
 
-          @config.each do |k,v|
-            unless required_config_items.include? k or optional_config_items.include? k
-              raise ArgumentError, "unknown configuration item found: #{k}"
-            end
-          end
+          ::PuppetX::BSD::Util.validate_config(
+            @config,
+            required_config_items,
+            optional_config_items
+          )
         end
 
         def content

--- a/lib/puppet_x/bsd/hostname_if/trunk.rb
+++ b/lib/puppet_x/bsd/hostname_if/trunk.rb
@@ -2,6 +2,7 @@
 #
 # Responsible for processing the trunk(4) interfaces for hostname_if(5)
 #
+require 'puppet_x/bsd/util'
 
 module PuppetX
   module BSD
@@ -12,35 +13,22 @@ module PuppetX
 
         def initialize(config)
           @config = config
-          validate_config()
-        end
-
-        def validate_config
-
-          # compensate for puppet oddities
-          @config.reject!{ |k,v| k == :undef or v == :undef }
+          ::PuppetX::BSD::Util.normalize_config(@config)
 
           required_config_items = [
             :interface,
             :proto,
           ]
 
-          # verify we have the required configuration items
-          required_config_items.each do |k,v|
-            unless @config.keys.include? k
-              raise ArgumentError, "#{k} is a required configuration item"
-            end
-          end
-
           optional_config_items = [
             :address,
           ]
 
-          @config.each do |k,v|
-            unless required_config_items.include? k or optional_config_items.include? k
-              raise ArgumentError, "unknown configuration item found: #{k}"
-            end
-          end
+          ::PuppetX::BSD::Util.validate_config(
+            @config,
+            required_config_items,
+            optional_config_items
+          )
         end
 
         def content

--- a/lib/puppet_x/bsd/hostname_if/vlan.rb
+++ b/lib/puppet_x/bsd/hostname_if/vlan.rb
@@ -3,6 +3,7 @@
 # Responsible for processing the vlan(4) interfaces for hostname_if(5)
 #
 
+require 'puppet_x/bsd/util'
 require 'puppet_x/bsd/hostname_if/inet'
 
 module PuppetX
@@ -14,38 +15,22 @@ module PuppetX
 
         def initialize(config)
           @config = config
-          validate_config()
-        end
-
-        def validate_config
-
-          # compensate for puppet oddities
-          @config.reject!{ |k,v|
-            k == :undef or v == :undef or v.length == 0
-          }
+          ::PuppetX::BSD::Util.normalize_config(@config)
 
           required_config_items = [
             :id,
             :device,
           ]
 
-          available_config_items = [
+          optional_config_items = [
             :address,
           ]
 
-          # verify we have the required configuration items
-          required_config_items.each do |k,v|
-            unless @config.keys.include? k
-              raise ArgumentError, "#{k} is a required configuration item"
-            end
-          end
-
-          @config.each do |k,v|
-            all_options = [available_config_items,required_config_items].flatten
-            unless all_options.include? k
-              raise ArgumentError, "unknown configuration item found: #{k}"
-            end
-          end
+          ::PuppetX::BSD::Util.validate_config(
+            @config,
+            required_config_items,
+            optional_config_items
+          )
         end
 
         # Return an array of values to place on each line

--- a/lib/puppet_x/bsd/hostname_if/wifi.rb
+++ b/lib/puppet_x/bsd/hostname_if/wifi.rb
@@ -15,6 +15,7 @@ module PuppetX
         def initialize(config)
           @config = config
           ::PuppetX::BSD::Util.normalize_config(@config)
+
           required_config_items = [
             :network_name,
           ]

--- a/lib/puppet_x/bsd/rc_conf/vlan.rb
+++ b/lib/puppet_x/bsd/rc_conf/vlan.rb
@@ -2,8 +2,7 @@
 #
 # Responsible for processing the vlan(4) interfaces for rc.conf(5)
 #
-
-#require 'puppet_x/bsd/hostname_if/inet'
+require 'puppet_x/bsd/util'
 
 module PuppetX
   module BSD
@@ -14,38 +13,22 @@ module PuppetX
 
         def initialize(config)
           @config = config
-          validate_config()
-        end
-
-        def validate_config
-
-          # compensate for puppet oddities
-          @config.reject!{ |k,v|
-            k == :undef or v == :undef or v.to_s.length == 0
-          }
+          ::PuppetX::BSD::Util.normalize_config(@config)
 
           required_config_items = [
             :id,
             :device,
           ]
 
-          available_config_items = [
+          optional_config_items = [
             :address,
           ]
 
-          # verify we have the required configuration items
-          required_config_items.each do |k,v|
-            unless @config.keys.include? k
-              raise ArgumentError, "#{k} is a required configuration item"
-            end
-          end
-
-          @config.each do |k,v|
-            all_options = [available_config_items,required_config_items].flatten
-            unless all_options.include? k
-              raise ArgumentError, "unknown configuration item found: #{k}"
-            end
-          end
+          ::PuppetX::BSD::Util.validate_config(
+            @config,
+            required_config_items,
+            optional_config_items
+          )
         end
 
         # Return an array of parsed values

--- a/lib/puppet_x/bsd/util.rb
+++ b/lib/puppet_x/bsd/util.rb
@@ -2,14 +2,15 @@ module PuppetX
   module BSD
     class Util
       def self.normalize_config(config)
-        raise ArgumentError,
-          "Config object must be a Hash" unless config.is_a? Hash
+        # Modify the config object to reject all undef values
+        raise ArgumentError, "Config object must be a Hash" unless config.is_a? Hash
         config.reject!{|k,v| k == :undef or v == :undef }
       end
 
       def self.validate_config(config,required_items,optional_items)
-        raise ArgumentError,
-          "Config object must be a Hash" unless config.is_a? Hash
+        # Ensure that all of the required params are passed, and that the rest
+        # of the options requested are valid
+        raise ArgumentError, "Config object must be a Hash" unless config.is_a? Hash
         required_items.each do |k,v|
           unless config.keys.include? k
             raise ArgumentError, "#{k} is a required configuration item"

--- a/spec/unit/bsd/rc_conf/vlan_spec.rb
+++ b/spec/unit/bsd/rc_conf/vlan_spec.rb
@@ -51,8 +51,7 @@ describe 'PuppetX::BSD::Rc_conf::Vlan' do
         }.not_to raise_error
       end
 
-
-      it "should raise an error if missing arguments" do
+      it "should raise an error when an invalid option is received" do
         c = {
           :id      => '1',
           :device  => 'em0',


### PR DESCRIPTION
This just cleans up the config validation code so we centralize its use
in a single place.  Without this change, the code is a bit noisier than
it otherwise would be.