### PR TITLE
Implement platform providers for bsd_interface

### DIFF
--- a/lib/puppet/provider/bsd_interface/freebsd.rb
+++ b/lib/puppet/provider/bsd_interface/freebsd.rb
@@ -1,0 +1,8 @@
+Puppet::Type.type(:bsd_interface).provide(:freebsd, :parent => :ifconfig) do
+  confine :kernel => [:freebsd]
+  defaultfor :kernel => [:freebsd]
+
+  def restart
+    execute(['/usr/sbin/service', 'netif', 'restart', resource[:name]], :failonfail => false)
+  end
+end

--- a/lib/puppet/provider/bsd_interface/ifconfig.rb
+++ b/lib/puppet/provider/bsd_interface/ifconfig.rb
@@ -2,7 +2,6 @@ Puppet::Type.type(:bsd_interface).provide(:ifconfig) do
   desc "Manage a BSD network interface state"
 
   confine :kernel => [:openbsd, :freebsd]
-  defaultfor :kernel => [:openbsd, :freebsd]
   commands :ifconfig => '/sbin/ifconfig'
   #mk_resource_methods
 

--- a/lib/puppet/provider/bsd_interface/openbsd.rb
+++ b/lib/puppet/provider/bsd_interface/openbsd.rb
@@ -1,0 +1,9 @@
+Puppet::Type.type(:bsd_interface).provide(:openbsd, :parent => :ifconfig) do
+  confine :kernel => [:openbsd]
+  defaultfor :kernel => [:openbsd]
+  commands :sh => 'sh'
+
+  def restart
+    sh('/etc/netstart', resource[:name])
+  end
+end

--- a/lib/puppet/type/bsd_interface.rb
+++ b/lib/puppet/type/bsd_interface.rb
@@ -33,4 +33,8 @@ Puppet::Type.newtype(:bsd_interface) do
     newvalue(:down)
     newvalue(:absent)
   end
+
+  def refresh
+    provider.restart
+  end
 end

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -75,14 +75,7 @@ define bsd::network::interface (
       file { "/etc/hostname.${if_name}":
         ensure  => $file_ensure,
         content => $text,
-      }
-
-      if $file_ensure == 'present' {
-        exec { "netstart_${if_name}":
-          command     => "/bin/sh /etc/netstart ${if_name}",
-          refreshonly => true,
-          subscribe   => File["/etc/hostname.${if_name}"],
-        }
+        notify  => Bsd_interface[$if_name],
       }
 
       bsd_interface { $if_name:
@@ -94,7 +87,8 @@ define bsd::network::interface (
 
       Shell_config {
         ensure => $file_ensure,
-        file   => '/etc/rc.conf'
+        file   => '/etc/rc.conf',
+        notify => Bsd_interface[$if_name],
       }
 
       create_resources('shell_config', $rec_hash)
@@ -103,11 +97,6 @@ define bsd::network::interface (
         $action = 'start'
       } elsif $state == 'down' {
         $action = 'stop'
-      }
-
-      exec { "netifstart_${if_name}":
-        command     => "/usr/sbin/service netif ${action} ${if_name}",
-        refreshonly => true,
       }
 
       bsd_interface { $if_name:


### PR DESCRIPTION
This enables refresh for the bsd_interface in a platform specific way.
Resources may now use the notify/subscribe meta-params.  If a resource is
notified, the provider will execute the platform specific method for
restarting an interface.