### PR TITLE
Drop support for ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
 script: bundle exec rake test


### PR DESCRIPTION
Both platforms that this module supports ship with 2.x versions of Ruby
and I'd like not to support 1.9 anymore.  Here we drop testing support.