### PR TITLE
Support addresses on trunk interfaces

### DIFF
--- a/lib/puppet_x/bsd/hostname_if/trunk.rb
+++ b/lib/puppet_x/bsd/hostname_if/trunk.rb
@@ -3,6 +3,7 @@
 # Responsible for processing the trunk(4) interfaces for hostname_if(5)
 #
 require 'puppet_x/bsd/util'
+require 'puppet_x/bsd/hostname_if/inet'
 
 module PuppetX
   module BSD
@@ -31,10 +32,22 @@ module PuppetX
           )
         end
 
-        def content
+        def values
+          inet = []
+          if @config[:address]
+            PuppetX::BSD::Hostname_if::Inet.new(@config[:address]).process {|i|
+              inet << i
+            }
+          end
+
           data = []
-          data << trunk_string()
-          data.join(' ')
+          data << trunk_string
+          data << inet if inet
+          data.flatten
+        end
+
+        def content
+          values.join("\n")
         end
 
         def trunk_string

--- a/manifests/network/interface/trunk.pp
+++ b/manifests/network/interface/trunk.pp
@@ -25,11 +25,18 @@ define bsd::network::interface::trunk (
     address   => $address,
   }
 
-  $trunk_ifconfig = get_hostname_if_trunk($config)
+  case $::kernel {
+    'FreeBSD': {
+      fail('trunk interfaces not implemnted on FreeBSD')
+    }
+    'OpenBSD': {
+      $trunk_values = get_hostname_if_trunk($config)
+    }
+  }
 
   bsd::network::interface { $if_name:
     ensure      => $ensure,
     description => $description,
-    values      => [$trunk_ifconfig],
+    values      => $trunk_values,
   }
 }

--- a/spec/defines/bsd_network_interface_trunk_spec.rb
+++ b/spec/defines/bsd_network_interface_trunk_spec.rb
@@ -19,6 +19,32 @@ describe "bsd::network::interface::trunk" do
         should contain_file('/etc/hostname.trunk0').with_content(/description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\nup\n/)
       end
     end
+
+    context "an example with an address" do
+      let(:params) { {
+          :interface => ['em0', 'em1'],
+          :description => "TestNet",
+          :address => 'fc01::/64'
+      } }
+      it do
+        should contain_bsd__network__interface('trunk0')
+        should contain_file('/etc/hostname.trunk0').with_content(
+          /description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\ninet6 fc01:: 64\nup\n/)
+      end
+    end
+
+    context "an example with multiple addresses" do
+      let(:params) { {
+          :interface => ['em0', 'em1'],
+          :description => "TestNet",
+          :address => ['fc01::/64', '10.0.0.1/24'],
+      } }
+      it do
+        should contain_bsd__network__interface('trunk0')
+        should contain_file('/etc/hostname.trunk0').with_content(
+          /description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\ninet6 fc01:: 64\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
+      end
+    end
   end
 
   context "when a bad name is used" do


### PR DESCRIPTION
Without this change, addresses do not get configured correctly on trunk
interfaces.