### PR TITLE
Add "Installation" section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ package { 'ipaddress':
 }
 ```
 
+## Installation
+
+The easiest way to install is to install from the forge.
+
+```
+puppet module install zleslie/bsd
+```
+
 ## Network
 
 Network configuration is handled under the `bsd::network` name space.  Under


### PR DESCRIPTION
I was briefly confused by the difference between the xaque208 namespace on github and the zleslie one on puppet forge, so this helps document where the module can be found on puppet forge.