### PR TITLE
fix issue #75: add values parameter to all network/interface/*.pp classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ bsd::network::interface::vlan { 'vlan100':
   id      => '100',
   device  => 'em0',
   address => '10.0.0.1/24',
+  values  => ['!/sbin/route add -net 10.10.10.0/24 10.10.0.254',],
 }
 ```
 
@@ -141,6 +142,7 @@ bsd::network::interface::carp { "carp0":
   address => '10.0.0.1/24',
   carpdev => 'em0',
   pass    => 'TopSecret',
+  values  => ['!/sbin/route add -net 10.10.10.0/24 10.0.0.254',],
 }
 ```
 
@@ -185,6 +187,7 @@ bsd::network::interface::vlan { "vlan11":
   id      => '11',
   address => '10.0.11.1/24',
   device  => 'trunk0',
+  values  => ['!/sbin/route add -net 10.10.10.0/24 10.0.11.254',],
 }
 ```
 

--- a/manifests/network/interface/bridge.pp
+++ b/manifests/network/interface/bridge.pp
@@ -6,6 +6,7 @@ define bsd::network::interface::bridge (
   $interface,
   $ensure      = 'present',
   $description = undef,
+  $values      = undef,
 ) {
 
   $if_name = $name
@@ -23,9 +24,15 @@ define bsd::network::interface::bridge (
 
   $bridge_ifconfig = get_hostname_if_bridge($config)
 
+  if $values {
+    $bridge_values = concat([$bridge_ifconfig], $values)
+  } else {
+    $bridge_values = [$bridge_ifconfig]
+  }
+
   bsd::network::interface { $if_name:
     ensure      => $ensure,
     description => $description,
-    values      => [$bridge_ifconfig],
+    values      => $bridge_values,
   }
 }

--- a/manifests/network/interface/carp.pp
+++ b/manifests/network/interface/carp.pp
@@ -11,6 +11,7 @@ define bsd::network::interface::carp (
   $advskew     = undef,
   $description = undef,
   $pass        = undef,
+  $values      = undef,
 ) {
 
   include bsd::network::carp
@@ -35,9 +36,15 @@ define bsd::network::interface::carp (
 
   $carp_ifconfig = get_hostname_if_carp($config)
 
+  if $values {
+    $carp_values = concat([$carp_ifconfig], $values)
+  } else {
+    $carp_values = [$carp_ifconfig]
+  }
+
   bsd::network::interface { $if_name:
     ensure      => $ensure,
     description => $description,
-    values      => [$carp_ifconfig],
+    values      => $carp_values,
   }
 }

--- a/manifests/network/interface/trunk.pp
+++ b/manifests/network/interface/trunk.pp
@@ -8,6 +8,7 @@ define bsd::network::interface::trunk (
   $proto       = 'lacp',
   $address     = undef,
   $description = undef,
+  $values      = undef,
 ) {
 
   $if_name = $name
@@ -27,11 +28,17 @@ define bsd::network::interface::trunk (
 
   case $::kernel {
     'FreeBSD': {
-      fail('trunk interfaces not implemnted on FreeBSD')
+      fail('trunk interfaces not implemented on FreeBSD')
     }
     'OpenBSD': {
-      $trunk_values = get_hostname_if_trunk($config)
+      $trunk_ifconfig = get_hostname_if_trunk($config)
     }
+  }
+
+  if $values {
+    $trunk_values = concat([$trunk_ifconfig], $values)
+  } else {
+    $trunk_values = [$trunk_ifconfig]
   }
 
   bsd::network::interface { $if_name:

--- a/manifests/network/interface/wifi.pp
+++ b/manifests/network/interface/wifi.pp
@@ -9,6 +9,7 @@ define bsd::network::interface::wifi (
   $address     = undef,
   $description = undef,
   $options     = undef,
+  $values      = undef,
 ) {
 
   $if_name = $name
@@ -27,9 +28,15 @@ define bsd::network::interface::wifi (
 
   $wifi_ifconfig = get_hostname_if_wifi($config)
 
+  if $values {
+    $wifi_values = concat([$wifi_ifconfig], $values)
+  } else {
+    $wifi_values = [$wifi_ifconfig]
+  }
+
   bsd::network::interface { $if_name:
     description => $description,
-    values      => [$wifi_ifconfig],
+    values      => $wifi_values,
     options     => $options,
   }
 }

--- a/spec/defines/bsd_network_interface_bridge_spec.rb
+++ b/spec/defines/bsd_network_interface_bridge_spec.rb
@@ -19,6 +19,22 @@ describe "bsd::network::interface::bridge" do
         should contain_file('/etc/hostname.bridge0').with_content(/description "TestNet"\nadd em0\nadd em1\nup\n/)
       end
     end
+
+    context " a bit more extensive example with values set" do
+      let(:params) {
+        {
+          :interface => ['em0', 'em1'],
+          :values    => '!route add -net 10.10.10.0/24 10.0.0.254',
+        }
+      }
+      it do
+        should contain_bsd__network__interface('bridge0')
+      end
+
+      it do
+        should contain_file('/etc/hostname.bridge0').with_content(/add em0\nadd em1\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
+      end
+    end
   end
 
   context "when a bad name is used" do

--- a/spec/defines/bsd_network_interface_carp_spec.rb
+++ b/spec/defines/bsd_network_interface_carp_spec.rb
@@ -20,6 +20,25 @@ describe "bsd::network::interface::carp" do
         should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\nup\n/)
       end
     end
+
+    context " a bit more extensive example with values set" do
+      let(:params) {
+        {
+          :id      => '1',
+          :device  => 'em0',
+          :address => '10.0.0.1/24',
+          :advbase => '1',
+          :advskew => '0',
+          :pass    => 'TopSecret',
+          :values  => '!route add -net 10.10.10.0/24 10.0.0.254',
+        }
+      }
+      it do
+        should contain_bsd__network__interface('carp0')
+        should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
+      end
+    end
+
   end
 
   context "when a bad name is used" do

--- a/spec/defines/bsd_network_interface_vlan_spec.rb
+++ b/spec/defines/bsd_network_interface_vlan_spec.rb
@@ -20,6 +20,23 @@ describe "bsd::network::interface::vlan" do
         should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
       end
     end
+    context " a bit more extensive example with values set" do
+      let(:params) {
+        {
+          :id      => '1',
+          :device  => 'em0',
+          :address => '10.0.0.1/24',
+          :values  => '!route add -net 10.10.10.0/24 10.0.0.254',
+        }
+      }
+      it do
+        should contain_bsd__network__interface('vlan0')
+      end
+
+      it do
+        should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
+      end
+    end
   end
 
   context "when a bad name is used" do

--- a/spec/defines/bsd_network_interface_wifi_spec.rb
+++ b/spec/defines/bsd_network_interface_wifi_spec.rb
@@ -33,5 +33,28 @@ describe "bsd::network::interface::wifi" do
       should contain_file('/etc/hostname.athn0').with_content(/#{should_content}/)
     end
   end
+
+  context " a bit more extensive example with values set" do
+    let(:params) { {:network_name => 'myssid',
+                    :network_key => 'mysecretkey',
+                    :description => 'something good',
+                    :address => [
+                      '10.23.4.56/16',
+                      '2001:471:4336:ff::1/64',
+                    ],
+                    :options => [
+                      'chan 1',
+                      'media OFDM54',
+                      'mode 11g',
+                      'mediaopt hostap',
+                    ],
+                    :values  => '!route add -net 10.10.10.0/24 10.0.0.254',
+      }
+    }
+    it do
+      should_content =  "inet 10.23.4.56 255.255.0.0 NONE\ninet6 2001:471:4336:ff::1 64\nnwid myssid wpakey mysecretkey chan 1 media OFDM54 mode 11g mediaopt hostap description \"something good\"\n!route add -net 10.10.10.0\/24 10.0.0.254\nup"
+      should contain_file('/etc/hostname.athn0').with_content(/#{should_content}/)
+    end
+  end
 end
 


### PR DESCRIPTION
The values parameter, an array of strings, is intended to allow the user to set alias IP addresses, as well as shell commands, i.e. setting routes via !commands.

The values array, if given, is concatenated to the returned string of get_hostname_if_<INTERFACE_TYPE> functions, and then handed over to the values parameter of 'bsd::network::interface'

I only need it soon for carp interfaces, but thought all classes in that subdirectory should follow the same pattern, so I added it for all of them.

However, the vlan.pp was not following the pattern of the others, and now the FreeBSD test for vlan interfaces fails. I don't have a FreeBSD system around to test that. Do you have a possibility to verify that it creates a valid working FreeBSD config?
On OpenBSD, the config it created for VLAN interfaces was odd, looking like the following:
```
172.16.0.1/24 vlan 100 vlandev trunk0
 inet 172.16.0.1 255.255.255.0 NONE
 up
```

Now after the change, it creates files like:
```
vlan 100 vlandev trunk0
inet 172.16.0.1 255.255.255.0 NONE
up
```

The odd version it created was working fine, but the version it now creates is from my point of view saner.

In short: do you can let me know if VLANs for FreeBSD are now broken or do they work?
When they work, I'd rather go and adapt the spec test, if I broke it, I'll rework the vlan.pp in 
order to resemble behaviour as it was before.