### PR TITLE
Separate address parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Once you have the gateway set, you may wish to set some interface addresses.
 ```Puppet
 bsd::network::interface { 'em0':
   description => 'Primary Interface',
-  values      => [ '10.0.0.2/24', 'fc00::b0b/64' ],
+  addresses   => [ '10.0.0.2/24', 'fc00::b0b/64' ],
 }
 ```
 

--- a/lib/puppet/parser/functions/get_freebsd_rc_conf_shellconfig.rb
+++ b/lib/puppet/parser/functions/get_freebsd_rc_conf_shellconfig.rb
@@ -7,10 +7,11 @@ module Puppet::Parser::Functions
     config = args.shift
 
     c = {}
-    c[:name]    = config["name"] if config["name"]
-    c[:desc]    = config["description"] if config["description"]
-    c[:address] = config["values"] if config["values"]
-    c[:options] = config["options"] if config["options"]
+    c[:name]      = config["name"] if config["name"]
+    c[:desc]      = config["description"] if config["description"]
+    c[:addresses] = config["addresses"] if config["addresses"]
+    c[:options]   = config["options"] if config["options"]
+    c[:values]    = config["values"] if config["values"]
 
     return PuppetX::BSD::Rc_conf.new(c).to_create_resources
   end

--- a/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
+++ b/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
@@ -7,10 +7,11 @@ module Puppet::Parser::Functions
     config       = args.shift
 
     c = {}
-    c[:type]     = config["type"]
-    c[:desc]     = config["description"] if config["description"]
-    c[:values]   = config["values"] if config["values"]
-    c[:options]  = config["options"] if config["options"]
+    c[:type]      = config["type"]
+    c[:desc]      = config["description"] if config["description"]
+    c[:addresses] = config["addresses"] if config["addresses"]
+    c[:values]    = config["values"] if config["values"]
+    c[:options]   = config["options"] if config["options"]
 
     return PuppetX::BSD::Hostname_if.new(c).content
   end

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -14,6 +14,7 @@
 define bsd::network::interface (
   $ensure        = 'present',
   $description   = undef,
+  $addresses     = undef,
   $values        = undef,
   $options       = undef,
 ) {
@@ -32,6 +33,7 @@ define bsd::network::interface (
     'name'        => $name,
     'type'        => $if_type[0],
     'description' => $description,
+    'addresses'   => $addresses,
     'values'      => $values,
     'options'     => $options,
   }

--- a/spec/defines/bsd_network_interface_spec.rb
+++ b/spec/defines/bsd_network_interface_spec.rb
@@ -21,7 +21,23 @@ describe "bsd::network::interface" do
       end
     end
 
-    context "a vether device" do
+    context "a vether device using addresses and values parameter" do
+      let(:title) { 'vether0' }
+      let(:params) { {
+        :addresses => [ '123.123.123.123/29',
+          '172.16.0.1/27',
+          'fc01::/7',
+          '2001:100:fed:beef::/64', ],
+        :values => [ 'up', ]
+        }
+      }
+
+      it do
+        should contain_file('/etc/hostname.vether0').with_content(/inet 123.123.123.123 255.255.255.248 NONE\ninet alias 172.16.0.1 255.255.255.224 NONE\ninet6 fc01:: 7\ninet6 alias 2001:100:fed:beef:: 64\nup\n/)
+      end
+    end
+
+    context "a vether device using values parameter only" do
       let(:title) { 'vether0' }
       let(:params) { {
         :values => [ '123.123.123.123/29',

--- a/spec/unit/bsd/rc_conf_spec.rb
+++ b/spec/unit/bsd/rc_conf_spec.rb
@@ -34,7 +34,7 @@ describe 'PuppetX::BSD::Rc_conf' do
 
         c = {
           :name => 're0',
-          :address => [
+          :addresses => [
             'dhcp'
           ]
         }
@@ -48,7 +48,7 @@ describe 'PuppetX::BSD::Rc_conf' do
           }
           c = {
             :name   => 're0',
-            :address => [],
+            :addresses => [],
           }
 
           expect(rc.new(c).get_hash).to eq(hash)
@@ -62,7 +62,7 @@ describe 'PuppetX::BSD::Rc_conf' do
           }
           c = {
             :name   => 're0',
-            :address => [
+            :addresses => [
               '10.0.0.1/24'
             ],
           }
@@ -81,7 +81,7 @@ describe 'PuppetX::BSD::Rc_conf' do
           }
           c = {
             :name   => 're0',
-            :address => [
+            :addresses => [
               '10.0.0.1/24',
               '10.0.0.2/24',
               '10.0.0.3/24'
@@ -114,7 +114,7 @@ describe 'PuppetX::BSD::Rc_conf' do
         c = {
           :name   => 're0',
           :desc   => "Uplink",
-          :address => [
+          :addresses => [
             '10.0.1.12/24',
             '10.0.1.13/24',
             '10.0.1.14/24',
@@ -160,7 +160,7 @@ describe 'PuppetX::BSD::Rc_conf' do
         c = {
           :name   => 're0',
           :desc   => "Uplink",
-          :address => [
+          :addresses => [
             '10.0.1.12/24',
             '10.0.1.13/24',
             '10.0.1.14/24',


### PR DESCRIPTION

    Process addresses in a separate function in hostname_if.rb, but keep the
    old address parsing in process_items for backward compatibility.
    
    Add addresses parameter to manifests::network::interface, and pass it
    to get_openbsd_hostname_if_content function
    
    Add a spec test using the addresses parameter in the bsd_network_interface_spec.rb
    and update README.md
    
    Add addresses parameter handling for FreeBSD too
    Merge values into addresses in FreeBSD case in rc_conf.rb
    
    Add deprecation warning to hostname_if.rb if IP address info is set
    via values parameter, but no addresses parameter is given.
    Bail out, when trying to set IP info via values parameter and an
    addresses parameter is given too.


The big advantage is, that this way, IP addresses can be a bit more specifically validated, at some point in time, the IP address parsing from the values parser in hostname_if.rb to be removed.

Further, with the addresses paramter to bsd::network::interface, and the addresses parameters to the bsd::network::interfaces::* classes, this is a bit more consistent.
No need to overload the values parameter for alias IP addresses.

It's based on the other PR I opened, about the values parameter to the bsd::network::interface::* classes. 

This clean-up is a first step into the autorequire direction.

Does that make sense, anything to change/add/enhance?
