### PR TITLE
Handle parent interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ address and gateway.
 NOTE: This only sets the configuration, it does not currently set the running interfaces addresses.
 ```
 
+### Interface configuration order
+
+Clonable interfaces might require other interfaces to be configured first.
+The bsd::network::interface defined type has a 'parents' parameter that
+can take a string or array of interface names, that in turn will be
+required to be configured before. Note that the parent interfaces are not
+required to be managed via Puppet.
+
 ### Interfaces
 
 Interface configurations are handled per interface type.  Each supported type
@@ -155,6 +163,7 @@ They are directly supported by `bsd::network::interface` defined type.
 ```Puppet
 bsd::network::interface { "pfsync0":
   description => 'sync interface',
+  parents     => 'bge0',
   values      => [ 'syncdev bge0', ],
 }
 
@@ -213,6 +222,7 @@ defined type. I.e. an IPv6 via IPv4 tunnel could look like:
 ```Puppet
 bsd::network::interface { 'gif0':
   description => 'IPv6 in IPv4 tunnel',
+  parents     => 'em0',
   values      => [
     'tunnel 1.2.3.4 5.6.7.8',
     'inet6 alias 2001:470:6c:bbb::2 2001:470:6c:bbb::1 prefixlen 128',
@@ -239,6 +249,7 @@ class { 'bsd::network::gre':
 
 bsd::network::interface { 'gre0':
   description => 'Tunnel interface',
+  parents     => 'em0',
   values      => [
     '172.16.0.1 172.16.0.2 netmask 0xffffffff link0 up',
     'tunnel 1.2.3.4 5.6.7.8',
@@ -253,6 +264,7 @@ defined type.
 ```Puppet
 bsd::network::interface { 'pflow0':
   description => 'Pflow to collector',
+  parents     => 'em0',
   values      => [
     'flowsrc 1.2.3.4 flowdst 5.6.7.8:1234',
     'pflowproto 10',

--- a/lib/puppet/type/bsd_interface.rb
+++ b/lib/puppet/type/bsd_interface.rb
@@ -28,6 +28,25 @@ Puppet::Type.newtype(:bsd_interface) do
     defaultto :present
   end
 
+  newparam :parents do
+    desc "a String or Array of parent interfaces"
+    validate do |value|
+      if value.is_a? Array
+        value.each { |v|
+          if ! v.match(/[[:alpha:]]+[[:digit:]]+/)
+            raise ArgumentError, "got illegal parent interface: '#{v}' for '#{resource[:name]}'"
+          end
+        }
+      elsif value.is_a? String
+        if ! value.match(/[[:alpha:]]+[[:digit:]]+/)
+          raise ArgumentError, "got illegal parent interface: '#{value}' for '#{resource[:name]}'"
+        end
+      else
+        raise ArgumentError, "parents can only be a String or an Array, is: #{value.class}"
+      end
+    end
+  end
+
   newproperty(:state) do
     newvalue(:up)
     newvalue(:down)
@@ -37,4 +56,9 @@ Puppet::Type.newtype(:bsd_interface) do
   def refresh
     provider.restart
   end
+
+  autorequire(:bsd_interface) do
+    self[:parents]
+  end
+
 end

--- a/lib/puppet_x/bsd/hostname_if.rb
+++ b/lib/puppet_x/bsd/hostname_if.rb
@@ -41,7 +41,7 @@ module PuppetX
           :desc,
           :addresses,
           :values,
-          :options
+          :options,
         ]
 
         @config.each do |k,v|
@@ -60,7 +60,7 @@ module PuppetX
           end
         end
 
-        if @config[:desc] or @config[:values] or @config[:options]
+        if @config[:desc] or @config[:addresses] or @config[:values] or @config[:options]
           if @config[:desc]
             if @config[:desc].is_a? String
               @desc = @config[:desc]
@@ -96,9 +96,10 @@ module PuppetX
                 "options can only be a String or an Array, is: #{@config[:options].class}"
             end
           end
+
         else
           raise ArgumentError,
-            "a description, value, or option is required"
+            "a description, address, value, or option is required"
         end
       end
 

--- a/lib/puppet_x/bsd/rc_conf.rb
+++ b/lib/puppet_x/bsd/rc_conf.rb
@@ -19,7 +19,7 @@ module PuppetX
           :desc,
           :addresses,
           :options,
-          :values
+          :values,
         ]
 
         required_config_items = [

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -17,6 +17,7 @@ define bsd::network::interface (
   $addresses     = undef,
   $values        = undef,
   $options       = undef,
+  $parents       = undef,
 ) {
 
   $if_name        = $name
@@ -79,7 +80,9 @@ define bsd::network::interface (
       }
 
       bsd_interface { $if_name:
-        ensure => $ensure,
+        ensure  => $ensure,
+        parents => $parents,
+        require => File["/etc/hostname.${if_name}"],
       }
     }
     'FreeBSD': {
@@ -100,7 +103,9 @@ define bsd::network::interface (
       }
 
       bsd_interface { $if_name:
-        ensure => $ensure,
+        ensure  => $ensure,
+        parents => $parents,
+        require => Shell_config["ifconfig_${if_name}"],
       }
     }
     default: {

--- a/manifests/network/interface/bridge.pp
+++ b/manifests/network/interface/bridge.pp
@@ -34,5 +34,6 @@ define bsd::network::interface::bridge (
     ensure      => $ensure,
     description => $description,
     values      => $bridge_values,
+    parents     => [$interface],
   }
 }

--- a/manifests/network/interface/carp.pp
+++ b/manifests/network/interface/carp.pp
@@ -46,5 +46,6 @@ define bsd::network::interface::carp (
     ensure      => $ensure,
     description => $description,
     values      => $carp_values,
+    parents     => [$device],
   }
 }

--- a/manifests/network/interface/trunk.pp
+++ b/manifests/network/interface/trunk.pp
@@ -45,5 +45,6 @@ define bsd::network::interface::trunk (
     ensure      => $ensure,
     description => $description,
     values      => $trunk_values,
+    parents     => [$interface],
   }
 }

--- a/manifests/network/interface/vlan.pp
+++ b/manifests/network/interface/vlan.pp
@@ -36,6 +36,7 @@ define bsd::network::interface::vlan (
         description => $description,
         values      => $address,
         options     => $vlan_options,
+        parents     => [$device],
       }
     }
     'OpenBSD': {
@@ -51,6 +52,7 @@ define bsd::network::interface::vlan (
         ensure      => $ensure,
         description => $description,
         values      => $vlan_values,
+        parents     => [$device],
       }
     }
   }

--- a/spec/defines/bsd_network_interface_bridge_spec.rb
+++ b/spec/defines/bsd_network_interface_bridge_spec.rb
@@ -5,17 +5,30 @@ describe "bsd::network::interface::bridge" do
     let(:facts) { {:kernel => 'OpenBSD'} }
     let(:title) { 'bridge0' }
     context " a minimal example" do
-      let(:params) { {:interface => ['em0', 'em1']} }
+      let(:params) {
+        {
+          :interface => ['em0', 'em1']
+        }
+      }
       it do
-        should contain_bsd__network__interface('bridge0')
+        should contain_bsd__network__interface('bridge0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.bridge0').with_content(/add em0\nadd em1\nup\n/)
       end
     end
 
     context "a medium example" do
-      let(:params) { {:interface => ['em0', 'em1'], :description => "TestNet"} }
+      let(:params) {
+        {
+          :interface => ['em0', 'em1'],
+          :description => "TestNet"
+        }
+      }
       it do
-        should contain_bsd__network__interface('bridge0')
+        should contain_bsd__network__interface('bridge0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.bridge0').with_content(/description "TestNet"\nadd em0\nadd em1\nup\n/)
       end
     end
@@ -28,9 +41,8 @@ describe "bsd::network::interface::bridge" do
         }
       }
       it do
-        should contain_bsd__network__interface('bridge0')
+        should contain_bsd__network__interface('bridge0').with_parents(['em0', 'em1'])
       end
-
       it do
         should contain_file('/etc/hostname.bridge0').with_content(/add em0\nadd em1\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
       end

--- a/spec/defines/bsd_network_interface_carp_spec.rb
+++ b/spec/defines/bsd_network_interface_carp_spec.rb
@@ -16,7 +16,9 @@ describe "bsd::network::interface::carp" do
         }
       }
       it do
-        should contain_bsd__network__interface('carp0')
+        should contain_bsd__network__interface('carp0').with_parents(['em0'])
+      end
+      it do
         should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\nup\n/)
       end
     end
@@ -34,7 +36,9 @@ describe "bsd::network::interface::carp" do
         }
       }
       it do
-        should contain_bsd__network__interface('carp0')
+        should contain_bsd__network__interface('carp0').with_parents(['em0'])
+      end
+      it do
         should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
       end
     end

--- a/spec/defines/bsd_network_interface_spec.rb
+++ b/spec/defines/bsd_network_interface_spec.rb
@@ -10,6 +10,9 @@ describe "bsd::network::interface" do
       it do
         should contain_file('/etc/hostname.tun0').with_content(/description "simple"\njust a test\nup\n/)
       end
+      it do
+        should contain_bsd_interface('tun0').that_requires('File[/etc/hostname.tun0]')
+      end
     end
 
     context "a tun device" do
@@ -18,6 +21,12 @@ describe "bsd::network::interface" do
 
       it do
         should contain_file('/etc/hostname.tun0').with_content(/up\n!\/usr\/local\/bin\/openvpn/)
+      end
+      it do
+        should contain_file('/etc/hostname.tun0').that_notifies('Bsd_interface[tun0]')
+      end
+      it do
+        should contain_bsd_interface('tun0').that_requires('File[/etc/hostname.tun0]')
       end
     end
 
@@ -35,6 +44,12 @@ describe "bsd::network::interface" do
       it do
         should contain_file('/etc/hostname.vether0').with_content(/inet 123.123.123.123 255.255.255.248 NONE\ninet alias 172.16.0.1 255.255.255.224 NONE\ninet6 fc01:: 7\ninet6 alias 2001:100:fed:beef:: 64\nup\n/)
       end
+      it do
+        should contain_file('/etc/hostname.vether0').that_notifies('Bsd_interface[vether0]')
+      end
+      it do
+        should contain_bsd_interface('vether0').that_requires('File[/etc/hostname.vether0]')
+      end
     end
 
     context "a vether device using values parameter only" do
@@ -51,6 +66,12 @@ describe "bsd::network::interface" do
       it do
         should contain_file('/etc/hostname.vether0').with_content(/inet 123.123.123.123 255.255.255.248 NONE\ninet alias 172.16.0.1 255.255.255.224 NONE\ninet6 fc01:: 7\ninet6 alias 2001:100:fed:beef:: 64\nup\n/)
       end
+      it do
+        should contain_file('/etc/hostname.vether0').that_notifies('Bsd_interface[vether0]')
+      end
+      it do
+        should contain_bsd_interface('vether0').that_requires('File[/etc/hostname.vether0]')
+      end
     end
   end
 
@@ -63,6 +84,12 @@ describe "bsd::network::interface" do
       it do
         should contain_shell_config('ifconfig_igb0').with_value(/inet 10.0.0.1\/24/)
       end
+      it do
+        should contain_shell_config('ifconfig_igb0').that_notifies('Bsd_interface[igb0]')
+      end
+      it do
+        should contain_bsd_interface('igb0').that_requires('Shell_config[ifconfig_igb0]')
+      end
     end
 
     context "when processing a vlan interface with one address" do
@@ -72,9 +99,14 @@ describe "bsd::network::interface" do
       it do
         should contain_shell_config('ifconfig_vlan1').with_value(/inet 10.0.0.1\/24 vlan 1 vlandev em0/)
       end
-
       it do
         should contain_shell_config('ifconfig_vlan1').with_ensure('present')
+      end
+      it do
+        should contain_shell_config('ifconfig_vlan1').that_notifies('Bsd_interface[vlan1]')
+      end
+      it do
+        should contain_bsd_interface('vlan1').that_requires('Shell_config[ifconfig_vlan1]')
       end
     end
   end

--- a/spec/defines/bsd_network_interface_trunk_spec.rb
+++ b/spec/defines/bsd_network_interface_trunk_spec.rb
@@ -7,7 +7,9 @@ describe "bsd::network::interface::trunk" do
     context " a minimal example" do
       let(:params) { {:interface => ['em0', 'em1']} }
       it do
-        should contain_bsd__network__interface('trunk0')
+        should contain_bsd__network__interface('trunk0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.trunk0').with_content(/trunkproto lacp trunkport em0 trunkport em1\nup\n/)
       end
     end
@@ -15,7 +17,9 @@ describe "bsd::network::interface::trunk" do
     context "a medium example" do
       let(:params) { {:interface => ['em0', 'em1'], :description => "TestNet"} }
       it do
-        should contain_bsd__network__interface('trunk0')
+        should contain_bsd__network__interface('trunk0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.trunk0').with_content(/description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\nup\n/)
       end
     end
@@ -27,7 +31,9 @@ describe "bsd::network::interface::trunk" do
           :address => 'fc01::/64'
       } }
       it do
-        should contain_bsd__network__interface('trunk0')
+        should contain_bsd__network__interface('trunk0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.trunk0').with_content(
           /description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\ninet6 fc01:: 64\nup\n/)
       end
@@ -40,7 +46,9 @@ describe "bsd::network::interface::trunk" do
           :address => ['fc01::/64', '10.0.0.1/24'],
       } }
       it do
-        should contain_bsd__network__interface('trunk0')
+        should contain_bsd__network__interface('trunk0').with_parents(['em0', 'em1'])
+      end
+      it do
         should contain_file('/etc/hostname.trunk0').with_content(
           /description \"TestNet\"\ntrunkproto lacp trunkport em0 trunkport em1\ninet6 fc01:: 64\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
       end

--- a/spec/defines/bsd_network_interface_vlan_spec.rb
+++ b/spec/defines/bsd_network_interface_vlan_spec.rb
@@ -13,9 +13,8 @@ describe "bsd::network::interface::vlan" do
         }
       }
       it do
-        should contain_bsd__network__interface('vlan0')
+        should contain_bsd__network__interface('vlan0').with_parents(['em0'])
       end
-
       it do
         should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
       end
@@ -30,9 +29,8 @@ describe "bsd::network::interface::vlan" do
         }
       }
       it do
-        should contain_bsd__network__interface('vlan0')
+        should contain_bsd__network__interface('vlan0').with_parents(['em0'])
       end
-
       it do
         should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
       end
@@ -68,9 +66,11 @@ describe "bsd::network::interface::vlan" do
         }
       }
       it do
+        should contain_bsd__network__interface('vlan0').with_parents(['em0'])
+      end
+      it do
         should contain_bsd__network__interface('vlan0').with_options(['vlan 1', 'vlandev em0'])
       end
-
       it do
         should contain_bsd__network__interface('vlan0').with_values(['10.0.0.1/24'])
       end


### PR DESCRIPTION
Add a parents parameter to bsd::network::interface. This
can be a string or an array. The value of that parameter
is passed to Bsd_interface.rb when the interface is started.

Add a parents parameter to bsd_interface.rb, and autorequire
the parents. A bit of validation etc. of the interface name
done.

In bsd::network::interface, require the creation of hostname.if
for OpenBSD or the shell_config for FreeBSD to be done before
the Bsd_interface is created.

The subclasses in bsd::network::interface::* where parent interfaces
make sense to set, i.e. bridge, carp, trunk and vlan, deduct the
parent interface based on the interface or device parameter, and
hand that over to the parents parameter of bsd::network::interface.

Specs added for bsd::network::interface::* defined types, and
the parents defined types.


Tested on one of my soekris boxen, where I created a trunk0 on top of vr1, vr2, vr3.
On top of trunk0, there is vlan100, and on top of that, there is carp100.

Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Vlan[vlan100]/Bsd::Network::Interface[vlan100]/File[/etc/hostname.vlan100]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface::Vlan[vlan100]/Bsd::Network::Interface[vlan100]/File[/etc/hostname.vlan100]: Scheduling refresh of Bsd_interface[vlan100]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr3]/File[/etc/hostname.vr3]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr3]/File[/etc/hostname.vr3]: Scheduling refresh of Bsd_interface[vr3]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr3]/Bsd_interface[vr3]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr3]/Bsd_interface[vr3]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr1]/File[/etc/hostname.vr1]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr1]/File[/etc/hostname.vr1]: Scheduling refresh of Bsd_interface[vr1]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr1]/Bsd_interface[vr1]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr1]/Bsd_interface[vr1]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Carp[carp100]/Bsd::Network::Interface[carp100]/File[/etc/hostname.carp100]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface::Carp[carp100]/Bsd::Network::Interface[carp100]/File[/etc/hostname.carp100]: Scheduling refresh of Bsd_interface[carp100]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr2]/File[/etc/hostname.vr2]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr2]/File[/etc/hostname.vr2]: Scheduling refresh of Bsd_interface[vr2]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr2]/Bsd_interface[vr2]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface[vr2]/Bsd_interface[vr2]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Trunk[trunk0]/Bsd::Network::Interface[trunk0]/File[/etc/hostname.trunk0]/ensure: created
Info: /Stage[main]/Profile::Network/Bsd::Network::Interface::Trunk[trunk0]/Bsd::Network::Interface[trunk0]/File[/etc/hostname.trunk0]: Scheduling refresh of Bsd_interface[trunk0]
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Trunk[trunk0]/Bsd::Network::Interface[trunk0]/Bsd_interface[trunk0]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Trunk[trunk0]/Bsd::Network::Interface[trunk0]/Bsd_interface[trunk0]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Vlan[vlan100]/Bsd::Network::Interface[vlan100]/Bsd_interface[vlan100]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Vlan[vlan100]/Bsd::Network::Interface[vlan100]/Bsd_interface[vlan100]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Carp[carp100]/Bsd::Network::Interface[carp100]/Bsd_interface[carp100]/ensure: created
Notice: /Stage[main]/Profile::Network/Bsd::Network::Interface::Carp[carp100]/Bsd::Network::Interface[carp100]/Bsd_interface[carp100]: Triggered 'refresh' from 1 events

Without the autorequire, the carp was created before the vlan, and the vlan before the trunk, leaving a big mess behind ;)

However, I still have some trouble to get the specs test right for bsd_interface.rb. I wanted to test that it bails out when there is a wrong parent name given, and when there is something else given as string or array. Also I wanted to add a test to see that it correctly requires the other parent interfaces before itself, but somehow failed with that. Maybe you can give a hint/idea how to implement the tests properly.

At least wanted to show off what I have so far, waiting for feedback ;)

cheers,