### PR TITLE
Pfsync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ rvm:
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.8.3" STRICT_VARIABLES=yes
 sudo: false

--- a/README.md
+++ b/README.md
@@ -158,13 +158,15 @@ bsd::network::interface::carp { "carp0":
 
 #### pfsync(4)
 Closely related to carp(4) interfaces are the pfsync(4) interfaces.
-They are directly supported by `bsd::network::interface` defined type.
+They are supported by `bsd::network::interface::pfsync` defined type.
 
 ```Puppet
-bsd::network::interface { "pfsync0":
-  description => 'sync interface',
-  parents     => 'bge0',
-  values      => [ 'syncdev bge0', ],
+bsd::network::interface::pfsync { "pfsync0":
+  description => 'PF state sync interface',
+  syncdev     => 'bge0',
+  syncpeer    => '10.0.0.123',
+  maxupd      => 128,
+  defer       => false,
 }
 
 #### lagg(4) and trunk(4)

--- a/lib/puppet/parser/functions/get_hostname_if_pfsync.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_pfsync.rb
@@ -1,0 +1,17 @@
+require 'puppet_x/bsd/hostname_if/pfsync'
+
+module Puppet::Parser::Functions
+  newfunction(:get_hostname_if_pfsync,
+              :type => :rvalue) do |args|
+
+    config = args.shift
+
+    c = {}
+    c[:syncdev]  = config["syncdev"] if config["syncdev"]
+    c[:syncpeer] = config["syncpeer"] if config["syncpeer"]
+    c[:maxupd]   = config["maxupd"] if config["maxupd"]
+    c[:defer]    = config["defer"] if config["defer"]
+
+    return PuppetX::BSD::Hostname_if::Pfsync.new(c).content
+  end
+end

--- a/lib/puppet_x/bsd/hostname_if/pfsync.rb
+++ b/lib/puppet_x/bsd/hostname_if/pfsync.rb
@@ -1,0 +1,80 @@
+# Module: PuppetX::Hostname_if::Pfsync
+#
+# Responsible for processing the pfsync(4) interfaces for hostname_if(5)
+#
+require 'puppet_x/bsd/util'
+require 'puppet_x/bsd/hostname_if/inet'
+
+module PuppetX
+  module BSD
+    class Hostname_if
+      class Pfsync
+
+        attr_reader :content
+
+        def initialize(config)
+          @config = config
+          ::PuppetX::BSD::Util.normalize_config(@config)
+
+          required_config_items = []
+
+          optional_config_items = [
+            :syncdev,
+            :syncpeer,
+            :maxupd,
+            :defer,
+          ]
+
+          ::PuppetX::BSD::Util.validate_config(
+            @config,
+            required_config_items,
+            optional_config_items
+          )
+        end
+
+        def values
+          data = []
+          data << pfsync_string
+          data.flatten
+        end
+
+        def content
+          values.join("\n")
+        end
+
+        def pfsync_string
+          pfsyncstring = []
+          if @config[:syncdev]
+            pfsyncstring << 'syncdev' << @config[:syncdev]
+          else
+            pfsyncstring << '-syncdev'
+          end
+
+          if @config[:syncpeer]
+            pfsyncstring << 'syncpeer' << @config[:syncpeer]
+          else
+            pfsyncstring << '-syncpeer'
+          end
+
+          if @config[:maxupd]
+            if @config[:maxupd].to_i < 0 or @config[:maxupd].to_i > 255
+              raise ArgumentError, 'value of maxupd has to be in the range of 0 and 255'
+            end
+            pfsyncstring << 'maxupd' << @config[:maxupd]
+          else
+            pfsyncstring << 'maxupd' << '128'
+          end
+
+          if @config[:defer] == true
+            pfsyncstring << 'defer'
+          else
+            pfsyncstring << '-defer'
+          end
+
+          pfsyncstring.join(' ')
+        end
+      end
+    end
+  end
+end
+

--- a/manifests/network/interface/pfsync.pp
+++ b/manifests/network/interface/pfsync.pp
@@ -1,0 +1,52 @@
+# Define: bsd::network::interface::pfsync
+#
+# Handles the creation and configuration of pfsync(4) interfaces.
+#
+define bsd::network::interface::pfsync (
+  $ensure      = 'present',
+  $syncdev     = undef,
+  $syncpeer    = undef,
+  $maxupd      = undef,
+  $defer       = undef,
+  $description = undef,
+  $values      = undef,
+) {
+
+  $if_name = $name
+  validate_re($if_name, ['pfsync'])
+
+  validate_re(
+    $ensure,
+    '(up|down|present|absent)',
+    '$ensure can only be one of up, down, present, or absent'
+  )
+
+  $config = {
+    syncdev  => $syncdev,
+    syncpeer => $syncpeer,
+    maxupd   => $maxupd,
+    defer    => $defer,
+  }
+
+  case $::kernel {
+    'FreeBSD': {
+      fail('pfsync interfaces not implemented on FreeBSD')
+    }
+    'OpenBSD': {
+      $pfsync_ifconfig = get_hostname_if_pfsync($config)
+    }
+  }
+
+  if $values {
+    $pfsync_values = concat([$pfsync_ifconfig], $values)
+  } else {
+    $pfsync_values = [$pfsync_ifconfig]
+  }
+
+  bsd::network::interface { $if_name:
+    ensure      => $ensure,
+    description => $description,
+    values      => $pfsync_values,
+    parents     => [$syncdev],
+  }
+}

--- a/spec/defines/bsd_network_interface_pfsync_spec.rb
+++ b/spec/defines/bsd_network_interface_pfsync_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe "bsd::network::interface::pfsync" do
+  context "on OpenBSD" do
+    let(:facts) { {:kernel => 'OpenBSD'} }
+    let(:title) { 'pfsync0' }
+    context "an example with all default values" do
+      it do
+        should contain_bsd__network__interface('pfsync0')
+      end
+      it do
+        should contain_file('/etc/hostname.pfsync0').with_content(/-syncdev -syncpeer maxupd 128 -defer\nup\n/)
+      end
+    end
+
+    context "a minimal example" do
+      let(:params) { {:syncdev => ['em0']} }
+      it do
+        should contain_bsd__network__interface('pfsync0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.pfsync0').with_content(/syncdev em0 -syncpeer maxupd 128 -defer\nup\n/)
+      end
+    end
+
+    context "a medium example" do
+      let(:params) { {:syncdev => ['em0'], :description => "TestNet"} }
+      it do
+        should contain_bsd__network__interface('pfsync0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.pfsync0').with_content(/description \"TestNet\"\nsyncdev em0 -syncpeer maxupd 128 -defer\nup\n/)
+      end
+    end
+
+    context "an example with syncpeer" do
+      let(:params) { {
+          :syncdev => ['em0'],
+          :syncpeer => '10.0.0.222',
+      } }
+      it do
+        should contain_bsd__network__interface('pfsync0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.pfsync0').with_content(
+          /syncdev em0 syncpeer 10.0.0.222 maxupd 128 -defer\nup\n/)
+      end
+    end
+
+    context "an example with non-default maxupd and defer" do
+      let(:params) { {
+          :syncdev  => ['em0'],
+          :syncpeer => '10.0.0.222',
+          :maxupd   => '156',
+          :defer    => true,
+      } }
+      it do
+        should contain_bsd__network__interface('pfsync0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.pfsync0').with_content(
+          /syncdev em0 syncpeer 10.0.0.222 maxupd 156 defer\nup\n/)
+      end
+    end
+  end
+
+  context "when a bad name is used" do
+    let(:facts) { {:kernel => 'OpenBSD'} }
+    let(:title) { 'notcorrect0' }
+    let(:params) { {
+        :syncdev => ['em0'],
+        :description => "TestNet"
+    } }
+    it do
+      expect {
+          should contain_bsd__network__interface__pfsync('notcorrect0')
+      }.to raise_error(Puppet::Error, /does not match/)
+    end
+  end
+end

--- a/spec/unit/bsd/hostname_if/pfsync_spec.rb
+++ b/spec/unit/bsd/hostname_if/pfsync_spec.rb
@@ -1,0 +1,37 @@
+require 'puppet_x/bsd/hostname_if/pfsync'
+
+describe 'PuppetX::BSD::Hostname_if::Pfsync' do
+  describe 'validation' do
+    it "should raise an error if wrong argument" do
+      c = {
+        :proto     => 'lacp',
+      }
+      expect {
+        PuppetX::BSD::Hostname_if::Pfsync.new(c).content
+      }.to raise_error(ArgumentError, /unknown configuration item/)
+    end
+    it "should raise an error if maxupd value is out of range" do
+      c = {
+        :maxupd     => '256',
+      }
+      expect {
+        PuppetX::BSD::Hostname_if::Pfsync.new(c).content
+      }.to raise_error(ArgumentError, /value of maxupd has to be in the range of 0 and 255/)
+    end
+  end
+
+  describe 'content' do
+    it 'should support a minimal example' do
+      c = { }
+      expect(PuppetX::BSD::Hostname_if::Pfsync.new(c).content).to match(/-syncdev -syncpeer maxupd 128 -defer/)
+    end
+
+    it 'should support a partial example' do
+      c = {
+        :syncdev  => 'em0',
+        :syncpeer => '10.0.0.222',
+      }
+      expect(PuppetX::BSD::Hostname_if::Pfsync.new(c).content).to match(/syncdev em0 syncpeer 10.0.0.222 maxupd 128 -defer/)
+    end
+  end
+end


### PR DESCRIPTION
    Add special defined type for pfsync interfaces
    bsd::network::interface::pfsync
    
    This new type makes use of the parent interface of
    bsd::network::interface, setting the value of the syncdev
    parameter to the parent.
    
    README.md updated, and spec tests added for the new defined
    type and the corresponding hostname_if function.
    
    This defined type is a bit special compared to the others,
    since, when no parameters given, it explicitly sets the defaults
    
    i.e. just create a pfsync0 interface, without parameters will end
    up with a /etc/hostname.pfsync0 with:
    
    -syncdev -syncpeer maxupd 128 -defer
    up
    
    What is default anyways is taken from the pfsync manual page.
    
    This has the advantage that interfaces are easier to reconfigure.
    Instead of ensuring its absense, and re-creating it, a parameter
    can just be removed, and it will be reset to the default value.


This is a two commit PR, the second one enables Travis-CI runs for Puppet 3.8.3,
which is just available for OpenBSD 5.8-current.

