### PR TITLE
Add some validation of trunkprotos and vlan IDs

### DIFF
--- a/lib/puppet_x/bsd/hostname_if/trunk.rb
+++ b/lib/puppet_x/bsd/hostname_if/trunk.rb
@@ -52,6 +52,10 @@ module PuppetX
 
         def trunk_string
           trunkstring = []
+
+          if ! %w(broadcast failover lacp loadbalance none roundrobin).include? @config[:proto]
+            raise ArgumentError, "invalid trunk protocol: #{@config[:proto]}"
+          end
           trunkstring << 'trunkproto' << @config[:proto]
 
           if @config[:interface].is_a? Array

--- a/lib/puppet_x/bsd/hostname_if/vlan.rb
+++ b/lib/puppet_x/bsd/hostname_if/vlan.rb
@@ -54,6 +54,9 @@ module PuppetX
 
         def vlan_string
           vlanstring = []
+          if @config[:id].to_i < 1 or @config[:id].to_i > 4094
+            raise ArgumentError, "invalid vlan ID: #{@config[:id]}"
+          end
           vlanstring << 'vlan' << @config[:id]
           vlanstring << 'vlandev' << @config[:device]
           vlanstring.join(' ')

--- a/spec/unit/bsd/hostname_if/trunk_spec.rb
+++ b/spec/unit/bsd/hostname_if/trunk_spec.rb
@@ -17,8 +17,17 @@ describe 'PuppetX::BSD::Hostname_if::Trunk' do
         PuppetX::BSD::Hostname_if::Trunk.new(c).content
       }.to raise_error(ArgumentError, /interface.*required/)
     end
+    it "should raise an error on invalid trunk protocol" do
+      c = {
+        :proto     => 'hellwhatisthis',
+        :interface => 'em0',
+      }
+      expect {
+        PuppetX::BSD::Hostname_if::Trunk.new(c).content
+      }.to raise_error(ArgumentError, /invalid trunk protocol: hellwhatisthis/)
+    end
 
-    it "should raise an error if missing arguments" do
+    it "should raise an error with invalid parameter" do
       c = {
         :proto     => 'lacp',
         :interface => 'em0',

--- a/spec/unit/bsd/hostname_if/vlan_spec.rb
+++ b/spec/unit/bsd/hostname_if/vlan_spec.rb
@@ -39,7 +39,17 @@ describe 'PuppetX::BSD::Hostname_if::Vlan' do
       }.not_to raise_error
     end
 
-    it "should raise an error if missing arguments" do
+    it "should raise an error if invalid vlan id given" do
+      c = {
+        :id     => '4095',
+        :device => 'em0',
+      }
+      expect {
+        PuppetX::BSD::Hostname_if::Vlan.new(c).content
+      }.to raise_error(ArgumentError, /invalid vlan ID: 4095/)
+    end
+
+    it "should raise an error with invalid parameter" do
       c = {
         :id      => '1',
         :device  => 'em0',


### PR DESCRIPTION
Add a check in puppet_x/bsd/hostname_if/trunk.rb, to validate
the trunkprotos to only accept valid ones.
Add a check in puppet_x/bsd/hostname_if/vlan.rb to validate
valid vlan ids.
Add some spec tests to verify it's bailing out if invalid
values given.