### PR TITLE
Fixup bsd::network::interface::carp with multiple addresses given

### DIFF
--- a/lib/puppet_x/bsd/hostname_if/carp.rb
+++ b/lib/puppet_x/bsd/hostname_if/carp.rb
@@ -43,9 +43,9 @@ module PuppetX
           }
 
           data = []
-          data << inet
           data << carp_string()
-          data.join(' ')
+          data << inet if inet
+          data.join("\n")
         end
 
         def carp_string

--- a/spec/defines/bsd_network_interface_carp_spec.rb
+++ b/spec/defines/bsd_network_interface_carp_spec.rb
@@ -19,7 +19,7 @@ describe "bsd::network::interface::carp" do
         should contain_bsd__network__interface('carp0').with_parents(['em0'])
       end
       it do
-        should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\nup\n/)
+        should contain_file('/etc/hostname.carp0').with_content(/vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
       end
     end
 
@@ -39,10 +39,48 @@ describe "bsd::network::interface::carp" do
         should contain_bsd__network__interface('carp0').with_parents(['em0'])
       end
       it do
-        should contain_file('/etc/hostname.carp0').with_content(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
+        should contain_file('/etc/hostname.carp0').with_content(/vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE\n!route add -net 10.10.10.0\/24 10.0.0.254\nup\n/)
       end
     end
 
+    context " a bit more extensive example with multiple values set" do
+      let(:params) {
+        {
+          :id      => '1',
+          :device  => 'em0',
+          :address => '10.0.0.1/24',
+          :advbase => '1',
+          :advskew => '0',
+          :pass    => 'TopSecret',
+          :values  => [ '!route add -net 10.10.10.0/24 10.0.0.254', '!route add -net 10.20.10.0/24 10.0.0.254', ],
+        }
+      }
+      it do
+        should contain_bsd__network__interface('carp0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.carp0').with_content(/vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE\n!route add -net 10.10.10.0\/24 10.0.0.254\n!route add -net 10.20.10.0\/24 10.0.0.254\nup\n/)
+      end
+    end
+
+    context " a bit more extensive example with multiple addresses" do
+      let(:params) {
+        {
+          :id      => '1',
+          :device  => 'em0',
+          :address => [ '10.0.0.1/24', '10.0.0.2/32', '10.0.0.3/32' ],
+          :advbase => '1',
+          :advskew => '0',
+          :pass    => 'TopSecret',
+        }
+      }
+      it do
+        should contain_bsd__network__interface('carp0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.carp0').with_content(/vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE\ninet alias 10.0.0.2 255.255.255.255 NONE\ninet alias 10.0.0.3 255.255.255.255 NONE\nup\n/)
+      end
+    end
   end
 
   context "when a bad name is used" do

--- a/spec/defines/bsd_network_interface_vlan_spec.rb
+++ b/spec/defines/bsd_network_interface_vlan_spec.rb
@@ -19,6 +19,21 @@ describe "bsd::network::interface::vlan" do
         should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\nup\n/)
       end
     end
+    context " a minimal example with multiple addresses" do
+      let(:params) {
+        {
+          :id      => '1',
+          :device  => 'em0',
+          :address => [ '10.0.0.1/24', '10.0.0.2/32', ],
+        }
+      }
+      it do
+        should contain_bsd__network__interface('vlan0').with_parents(['em0'])
+      end
+      it do
+        should contain_file('/etc/hostname.vlan0').with_content(/vlan 1 vlandev em0\ninet 10.0.0.1 255.255.255.0 NONE\ninet alias 10.0.0.2 255.255.255.255 NONE\nup\n/)
+      end
+    end
     context " a bit more extensive example with values set" do
       let(:params) {
         {

--- a/spec/defines/bsd_network_interface_wifi_spec.rb
+++ b/spec/defines/bsd_network_interface_wifi_spec.rb
@@ -4,7 +4,7 @@ describe "bsd::network::interface::wifi" do
   let(:facts) { {:kernel => 'OpenBSD'} }
   let(:title) { 'athn0' }
 
-  context "with minimal paramaters" do
+  context "with minimal parameters" do
     let(:params) { {:network_name => 'myssid', :network_key => 'mysecretkey'} }
 
     it do
@@ -12,7 +12,7 @@ describe "bsd::network::interface::wifi" do
     end
   end
 
-  context "with minimal paramaters" do
+  context "with more parameters" do
     let(:params) { {:network_name => 'myssid',
                     :network_key => 'mysecretkey',
                     :description => 'something good',

--- a/spec/unit/bsd/hostname_if/carp_spec.rb
+++ b/spec/unit/bsd/hostname_if/carp_spec.rb
@@ -40,7 +40,7 @@ describe 'PuppetX::BSD::Hostname_if::Carp' do
         :advskew => '0',
         :pass    => 'TopSecret',
       }
-      expect(PuppetX::BSD::Hostname_if::Carp.new(c).content).to match(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0/)
+      expect(PuppetX::BSD::Hostname_if::Carp.new(c).content).to match(/vhid 1 pass TopSecret carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE/)
     end
 
     it 'should support a partial example' do
@@ -51,7 +51,7 @@ describe 'PuppetX::BSD::Hostname_if::Carp' do
         :advbase => '1',
         :advskew => '0',
       }
-      expect(PuppetX::BSD::Hostname_if::Carp.new(c).content).to match(/inet 10.0.0.1 255.255.255.0 NONE vhid 1 carpdev em0 advbase 1 advskew 0/)
+      expect(PuppetX::BSD::Hostname_if::Carp.new(c).content).to match(/vhid 1 carpdev em0 advbase 1 advskew 0\ninet 10.0.0.1 255.255.255.0 NONE/)
     end
   end
 end


### PR DESCRIPTION
    Fixup carp with multiple addresses, and add specs to test for
    that as well as adding specs for giving multiple values to
    carp interfaces.
    
    When there were multiple addresses given as an array, they were
    only added onto a single line, breaking sh /etc/netstart carpXXX
    
    Now correctly joining the data in lib/puppet_x/bsd/hostname_if/carp.rb
    with a "\n" instead of the wrong ' '.
    While there, I reordered the lines, like to have the same order
    as done in the trunk interface.
    
    Updating spec tests, to deal with that new order of lines, as well
    as adding a test to check for IP addresses given as array as well
    as values parameter given as array.


Second commit:

    Add a multiple addresses spec test for vlan interfaces, and add
    typos in wifi spec.