### PR TITLE
Implement flush

### DIFF
--- a/lib/puppet/type/bsd_interface.rb
+++ b/lib/puppet/type/bsd_interface.rb
@@ -48,9 +48,24 @@ Puppet::Type.newtype(:bsd_interface) do
   end
 
   newproperty(:state) do
+    desc "The state of the interface"
     newvalue(:up)
     newvalue(:down)
     newvalue(:absent)
+  end
+
+  newproperty(:destroyable) do
+    desc "Booleana representing if the interface is a pseudo interface"
+    newvalue(:true)
+    newvalue(:false)
+  end
+
+  newproperty(:flags) do
+    desc "Interface flags from ifconfig(8)"
+  end
+
+  newproperty(:mtu) do
+    desc "Running MTU of the interface"
   end
 
   def refresh

--- a/lib/puppet_x/bsd/ifconfig.rb
+++ b/lib/puppet_x/bsd/ifconfig.rb
@@ -20,7 +20,6 @@ module PuppetX
 
       def parse_interface_lines(output)
         curint = nil
-        intlines = {}
         output.lines {|line|
           line.chomp!
 
@@ -33,7 +32,6 @@ module PuppetX
               yield Hash({curint => t})
             }
           end
-
 
           if curint
             parse_interface_tokens(line.strip) {|t|

--- a/spec/unit/bsd/ifconfig_spec.rb
+++ b/spec/unit/bsd/ifconfig_spec.rb
@@ -1,6 +1,6 @@
 require 'puppet_x/bsd/ifconfig'
 
-describe 'PUppetX::BSD::Ifconfig' do
+describe 'PuppetX::BSD::Ifconfig' do
   context "on OpenBSD" do
     context '#parse' do
       it "should return the desired hash for a single interface" do


### PR DESCRIPTION
The primary goal of this work is to reduce the number of calls to
ifconfig during execution.  On a low power system with lots of
interfaces, the calls to ifconfig represent a not-insignificant of the
total time for catalog application.