### PR TITLE
Update module dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,5 +13,7 @@ fixtures:
       repo: 'git://github.com/duritong/puppet-sysctl'
       ref: '0.0.5'
   forge_modules:
-    shell_config: 'csail/shell_config'
+    augeasproviders: 'herculesteam/augeasproviders'
+    augeasproviders_core: 'herculesteam/augeasproviders_core'
+    augeasproviders_shellvar: 'herculesteam/augeasproviders_shellvar'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 .bundle
 pkg/
+spec/fixtures/manifests/
+spec/fixtures/modules/

--- a/lib/puppet/parser/functions/get_freebsd_rc_conf_shellvar.rb
+++ b/lib/puppet/parser/functions/get_freebsd_rc_conf_shellvar.rb
@@ -1,7 +1,7 @@
 require_relative '../../../puppet_x/bsd/rc_conf'
 
 module Puppet::Parser::Functions
-  newfunction(:get_freebsd_rc_conf_shellconfig,
+  newfunction(:get_freebsd_rc_conf_shellvar,
               :type => :rvalue) do |args|
 
     config = args.shift

--- a/lib/puppet_x/bsd/rc_conf.rb
+++ b/lib/puppet_x/bsd/rc_conf.rb
@@ -63,7 +63,7 @@ module PuppetX
       end
 
       # Return a hash formatted for the create_resources() function
-      # in puppet see shell_config resource
+      # in puppet see shellvar resource
       def to_create_resources
         resources = {}
 
@@ -83,14 +83,12 @@ module PuppetX
                   key = "ifconfig_#{ifname}"
                 end
                 resources[key] = {
-                  "key"   => key,
                   "value" => i,
                 }
               }
             else
               key = "ifconfig_#{ifname}"
               resources[key] = {
-                "key"   => key,
                 "value" => @data[topkey][:addrs],
               }
             end
@@ -100,7 +98,6 @@ module PuppetX
             @data[topkey][:aliases].each_with_index {|a,i|
               key = "ifconfig_#{ifname}_alias#{i}"
               resources[key] = {
-                "key"   => key,
                 "value" => a,
               }
             }

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -59,60 +59,52 @@ class bsd::network (
       }
     }
     'freebsd': {
-      Shell_config { file => '/etc/rc.conf' }
+      Shellvar { target => '/etc/rc.conf' }
 
       # Should we enable IPv4 forwarding?
       if $v4forwarding {
-        shell_config { 'gateway_enable':
-          key   => 'gateway_enable',
+        shellvar { 'gateway_enable':
           value => 'YES',
         }
       } else {
-        shell_config { 'gateway_enable':
+        shellvar { 'gateway_enable':
           ensure => absent,
-          key    => 'gateway_enable',
           value  => 'YES',
         }
       }
 
       # Should we enable IPv6 forwarding?
       if $v6forwarding {
-        shell_config { 'ipv6_gateway_enable':
-          key   => 'ipv6_gateway_enable',
+        shellvar { 'ipv6_gateway_enable':
           value => 'YES',
         }
       } else {
-        shell_config { 'ipv6_gateway_enable':
+        shellvar { 'ipv6_gateway_enable':
           ensure => absent,
-          key    => 'ipv6_gateway_enable',
           value  => 'YES',
         }
       }
 
       # What is our IPv4 default router?
       if $v4gateway != '' {
-        shell_config { 'defaultrouter':
-          key   => 'defaultrouter',
+        shellvar { 'defaultrouter':
           value => $v4gateway,
         }
       } else {
-        shell_config { 'defaultrouter':
+        shellvar { 'defaultrouter':
           ensure => absent,
-          key    => 'defaultrouter',
           value  => $v4gateway,
         }
       }
 
       # What is our IPv6 default router?
       if $v6gateway != '' {
-        shell_config { 'ipv6_defaultrouter':
-          key   => 'ipv6_defaultrouter',
+        shellvar { 'ipv6_defaultrouter':
           value => $v6gateway,
         }
       } else {
-        shell_config { 'ipv6_defaultrouter':
+        shellvar { 'ipv6_defaultrouter':
           ensure => absent,
-          key    => 'ipv6_defaultrouter',
           value  => $v6gateway,
         }
       }

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -86,15 +86,15 @@ define bsd::network::interface (
       }
     }
     'FreeBSD': {
-      $rec_hash = get_freebsd_rc_conf_shellconfig($config)
+      $rec_hash = get_freebsd_rc_conf_shellvar($config)
 
-      Shell_config {
+      Shellvar {
         ensure => $file_ensure,
-        file   => '/etc/rc.conf',
+        target => '/etc/rc.conf',
         notify => Bsd_interface[$if_name],
       }
 
-      create_resources('shell_config', $rec_hash)
+      create_resources('shellvar', $rec_hash)
 
       if $state == 'up' {
         $action = 'start'
@@ -105,7 +105,7 @@ define bsd::network::interface (
       bsd_interface { $if_name:
         ensure  => $ensure,
         parents => $parents,
-        require => Shell_config["ifconfig_${if_name}"],
+        require => Shellvar["ifconfig_${if_name}"],
       }
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,9 @@
   "description": "A module to manage parts of BSD",
   "dependencies": [
     { "name": "puppetlabs/concat", "version_requirement": ">= 1.2.5" },
-    { "name": "csail/shell_config", "version_requirement": ">= 0.0.1" },
+    { "name": "herculesteam/augeasproviders", "version_requirement": ">= 2.1.0" },
+    { "name": "herculesteam-augeasproviders_core", "version_requirement": ">= 2.1.0" },
+    { "name": "herculesteam-augeasproviders_shellvar", "version_requirement": ">= 2.2.0" },
     { "name": "duritong/sysctl", "version_requirement": ">= 0.0.5" },
     { "name": "puppetlabs/stdlib","version_requirement":">=4.4.0"}
   ]

--- a/spec/defines/bsd_network_interface_spec.rb
+++ b/spec/defines/bsd_network_interface_spec.rb
@@ -82,13 +82,13 @@ describe "bsd::network::interface" do
       let(:params) { {:values => ['10.0.0.1/24'], :description => 'simple' } }
 
       it do
-        should contain_shell_config('ifconfig_igb0').with_value(/inet 10.0.0.1\/24/)
+        should contain_shellvar('ifconfig_igb0').with_value(/inet 10.0.0.1\/24/)
       end
       it do
-        should contain_shell_config('ifconfig_igb0').that_notifies('Bsd_interface[igb0]')
+        should contain_shellvar('ifconfig_igb0').that_notifies('Bsd_interface[igb0]')
       end
       it do
-        should contain_bsd_interface('igb0').that_requires('Shell_config[ifconfig_igb0]')
+        should contain_bsd_interface('igb0').that_requires('Shellvar[ifconfig_igb0]')
       end
     end
 
@@ -97,16 +97,16 @@ describe "bsd::network::interface" do
       let(:params) { {:values => ['10.0.0.1/24'], :options => ['vlan 1', 'vlandev em0'] } }
 
       it do
-        should contain_shell_config('ifconfig_vlan1').with_value(/inet 10.0.0.1\/24 vlan 1 vlandev em0/)
+        should contain_shellvar('ifconfig_vlan1').with_value(/inet 10.0.0.1\/24 vlan 1 vlandev em0/)
       end
       it do
-        should contain_shell_config('ifconfig_vlan1').with_ensure('present')
+        should contain_shellvar('ifconfig_vlan1').with_ensure('present')
       end
       it do
-        should contain_shell_config('ifconfig_vlan1').that_notifies('Bsd_interface[vlan1]')
+        should contain_shellvar('ifconfig_vlan1').that_notifies('Bsd_interface[vlan1]')
       end
       it do
-        should contain_bsd_interface('vlan1').that_requires('Shell_config[ifconfig_vlan1]')
+        should contain_bsd_interface('vlan1').that_requires('Shellvar[ifconfig_vlan1]')
       end
     end
   end

--- a/spec/functions/get_freebsd_rc_conf_shellvar_spec.rb
+++ b/spec/functions/get_freebsd_rc_conf_shellvar_spec.rb
@@ -1,15 +1,12 @@
-describe 'get_freebsd_rc_conf_shellconfig' do
+describe 'get_freebsd_rc_conf_shellvar' do
   hash = {
     'ifconfig_re0' => {
-      'key'   => 'ifconfig_re0',
       'value' => 'inet 10.0.1.12/24 mtu 9000',
     },
     'ifconfig_re0_alias0' => {
-      'key'   => 'ifconfig_re0_alias0',
       'value' => 'inet 10.0.1.13/24',
     },
     'ifconfig_re0_alias1' => {
-      'key'   => 'ifconfig_re0_alias1',
       'value' => 'inet 10.0.1.14/24',
     },
   }

--- a/spec/unit/bsd/rc_conf_spec.rb
+++ b/spec/unit/bsd/rc_conf_spec.rb
@@ -136,23 +136,18 @@ describe 'PuppetX::BSD::Rc_conf' do
       it 'should convert the hash for create_resources()' do
         hash = {
           'ifconfig_re0' => {
-            'key'   => 'ifconfig_re0',
             'value' => 'inet 10.0.1.12/24 mtu 9000',
           },
           'ifconfig_re0_alias0' => {
-            'key'   => 'ifconfig_re0_alias0',
             'value' => 'inet 10.0.1.13/24',
           },
           'ifconfig_re0_alias1' => {
-            'key'   => 'ifconfig_re0_alias1',
             'value' => 'inet 10.0.1.14/24',
           },
           'ifconfig_re0_ipv6' => {
-            'key'   => 'ifconfig_re0_ipv6',
             'value' => 'inet6 fc00::123/64',
           },
           'ifconfig_re0_alias2' => {
-            'key'   => 'ifconfig_re0_alias2',
             'value' => 'inet6 fc00::124/64',
           },
         }
@@ -179,7 +174,6 @@ describe 'PuppetX::BSD::Rc_conf' do
       it 'should convert the hash for create_resources()' do
         hash = {
           'ifconfig_vlan100' => {
-            'key'   => 'ifconfig_vlan100',
             'value' => 'vlan 100 vlandev re0',
           }
         }


### PR DESCRIPTION
    This module now has three extra module dependencies, and drops
    shell_config as a requirement.  The augeas providers are under active
    development, and the providers are growing for a number of other types.
    As such, to avoid needing two different modules that fundamentally do
    the same thing, this change is my preference.

    To update, simply have a look at the new dependencies and install the
    needed modules.  If you are currently using shell_config elsewhere in
    your environment, there will be no conflict, so you may go about your
    day.  If you are not using shell_config elsewhere in your environment,
    updating to this module would prove a reasonable time to remove stop
    including it on your module list.