### PR TITLE
Changing sysctl module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,10 +10,11 @@ fixtures:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: '4.4.0'
     sysctl:
-      repo: 'git://github.com/duritong/puppet-sysctl'
-      ref: '0.0.5'
+      repo: 'https://github.com/hercules-team/augeasproviders_sysctl.git'
+      ref: '2.0.2'
   forge_modules:
     augeasproviders: 'herculesteam/augeasproviders'
     augeasproviders_core: 'herculesteam/augeasproviders_core'
     augeasproviders_shellvar: 'herculesteam/augeasproviders_shellvar'
+    augeasproviders_sysctl: 'herculesteam/augeasproviders_sysctl'
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ bsd::network::interface::pfsync { "pfsync0":
   maxupd      => 128,
   defer       => false,
 }
+```
 
 #### lagg(4) and trunk(4)
 ```Puppet

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -38,7 +38,7 @@ class bsd::network (
   if $v6forwarding {
     sysctl { 'net.inet6.ip6.forwarding':
       ensure => present,
-      value  => '0',
+      value  => '1',
     }
   } else {
     sysctl { 'net.inet6.ip6.forwarding':

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -24,15 +24,27 @@ class bsd::network (
 
   # Options common to both FreeBSD and OpenBSD
   if $v4forwarding {
-    sysctl::value { 'net.inet.ip.forwarding': value => '1' }
+    sysctl { 'net.inet.ip.forwarding':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.ip.forwarding': value => '0' }
+    sysctl { 'net.inet.ip.forwarding':
+      ensure => present,
+      value  => '0',
+    }
   }
 
   if $v6forwarding {
-    sysctl::value { 'net.inet6.ip6.forwarding': value => '1' }
+    sysctl { 'net.inet6.ip6.forwarding':
+      ensure => present,
+      value  => '0',
+    }
   } else {
-    sysctl::value { 'net.inet6.ip6.forwarding': value => '0' }
+    sysctl { 'net.inet6.ip6.forwarding':
+      ensure => present,
+      value  => '0',
+    }
   }
 
   case $::osfamily {

--- a/manifests/network/carp.pp
+++ b/manifests/network/carp.pp
@@ -8,14 +8,26 @@ class bsd::network::carp (
 ) {
 
   if $allowed == true {
-    sysctl::value { 'net.inet.carp.allow': value => '1' }
+    sysctl { 'net.inet.carp.allow':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.carp.allow': value => '0' }
+    sysctl { 'net.inet.carp.allow':
+      ensure => present,
+      value  => '0',
+    }
   }
 
   if $preempt == true {
-    sysctl::value { 'net.inet.carp.preempt': value => '1' }
+    sysctl { 'net.inet.carp.preempt':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.carp.preempt': value => '0' }
+    sysctl { 'net.inet.carp.preempt':
+      ensure => present,
+      value  => '0',
+    }
   }
 }

--- a/manifests/network/gre.pp
+++ b/manifests/network/gre.pp
@@ -10,20 +10,38 @@ class bsd::network::gre (
 ) {
 
   if $allowed == true {
-    sysctl::value { 'net.inet.gre.allow': value => '1' }
+    sysctl { 'net.inet.gre.allow':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.gre.allow': value => '0' }
+    sysctl { 'net.inet.gre.allow':
+      ensure => present,
+      value  => '0',
+    }
   }
 
   if $wccp == true {
-    sysctl::value { 'net.inet.gre.wccp': value => '1' }
+    sysctl { 'net.inet.gre.wccp':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.gre.wccp': value => '0' }
+    sysctl { 'net.inet.gre.wccp':
+      ensure => present,
+      value  => '0',
+    }
   }
 
   if $mobileip == true {
-    sysctl::value { 'net.inet.mobileip.allow': value => '1' }
+    sysctl { 'net.inet.mobileip.allow':
+      ensure => present,
+      value  => '1',
+    }
   } else {
-    sysctl::value { 'net.inet.mobileip.allow': value => '0' }
+    sysctl { 'net.inet.mobileip.allow':
+      ensure => present,
+      value  => '0',
+    }
   }
 }

--- a/manifests/network/interface.pp
+++ b/manifests/network/interface.pp
@@ -47,6 +47,9 @@ define bsd::network::interface (
     'absent': {
       $file_ensure = 'absent'
     }
+    default: {
+      fail('Incorrect file presence set')
+    }
   }
 
   # Set the interface state variable
@@ -56,6 +59,9 @@ define bsd::network::interface (
     }
     'absent','down': {
       $state = 'down'
+    }
+    default: {
+      fail('Incorrect state variable set')
     }
   }
 

--- a/manifests/network/interface/pfsync.pp
+++ b/manifests/network/interface/pfsync.pp
@@ -35,6 +35,9 @@ define bsd::network::interface::pfsync (
     'OpenBSD': {
       $pfsync_ifconfig = get_hostname_if_pfsync($config)
     }
+    default: {
+      fail('unhandled BSD, please help add support')
+    }
   }
 
   if $values {

--- a/manifests/network/interface/trunk.pp
+++ b/manifests/network/interface/trunk.pp
@@ -33,6 +33,9 @@ define bsd::network::interface::trunk (
     'OpenBSD': {
       $trunk_ifconfig = get_hostname_if_trunk($config)
     }
+    default: {
+      fail('unhandled BSD, please help add support')
+    }
   }
 
   if $values {

--- a/manifests/network/interface/vlan.pp
+++ b/manifests/network/interface/vlan.pp
@@ -55,5 +55,8 @@ define bsd::network::interface::vlan (
         parents     => flatten([$device]),
       }
     }
+    default: {
+      fail('unhandled BSD, please help add support')
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
     { "name": "herculesteam/augeasproviders", "version_requirement": ">= 2.1.0" },
     { "name": "herculesteam-augeasproviders_core", "version_requirement": ">= 2.1.0" },
     { "name": "herculesteam-augeasproviders_shellvar", "version_requirement": ">= 2.2.0" },
-    { "name": "duritong/sysctl", "version_requirement": ">= 0.0.5" },
+    { "name": "herculesteam-augeasproviders_sysctl", "version_requirement": ">= 2.02" },
     { "name": "puppetlabs/stdlib","version_requirement":">=4.4.0"}
   ]
 }


### PR DESCRIPTION
The currently referenced sysctl module hasn't been committed to since 2015, and https://github.com/hercules-team/augeasproviders_sysctl has been active and is "Approved" on the Puppet Forge. This module does this through augeas and puppet-bsd already uses their code.

Additionally, I've revised a markdown error in the README that was breaking the lagg section. 

Every case statement has had a default specified per best practice.
https://docs.puppet.com/puppet/latest/reference/lang_conditional.html#aside-best-practices