### PR TITLE
Update dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,12 +24,11 @@
     }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">= 4.5.1 < 5.0.0" }
+    { "name": "puppet", "version_requirement": ">= 4.5.1 < 6.0.0" }
   ],
   "description": "A module to manage parts of BSD",
   "dependencies": [
     { "name": "puppetlabs/concat", "version_requirement": ">= 1.2.5" },
-    { "name": "herculesteam/augeasproviders", "version_requirement": ">= 2.1.0" },
     { "name": "herculesteam-augeasproviders_core", "version_requirement": ">= 2.1.0" },
     { "name": "herculesteam-augeasproviders_shellvar", "version_requirement": ">= 2.2.0" },
     { "name": "herculesteam-augeasproviders_sysctl", "version_requirement": ">= 2.0.2" },


### PR DESCRIPTION
Here we update the version of puppet required to include 5.x, and we drop the
requirement for the augeasproviders module, since its not actually used and
causes puppet module list --tree to complain about missing dependencies.