### PR TITLE
Drop 5.7 rtsol support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ matrix:
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.0
     env: PUPPET_VERSION="~> 4.0" CHECK=test
-  - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
+#  - rvm: 2.4.0
+#    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
   - rvm: 2.4.0
     env: PUPPET_VERSION="~> 4.0" CHECK=build
 branches:

--- a/lib/puppet_x/bsd/hostname_if/inet.rb
+++ b/lib/puppet_x/bsd/hostname_if/inet.rb
@@ -4,7 +4,7 @@
 # hostname_if(5) format found on OpenBSD.
 #
 # Argument passed to #new must be a String of an IP address or an Array of IP
-# addresses, or strings of dynamic addressing methods (rtsol, inet6 autoconf or dhcp).
+# addresses, or strings of dynamic addressing methods (inet6 autoconf or dhcp).
 #
 
 require 'puppet/util/package'
@@ -38,15 +38,8 @@ module PuppetX
         def process
           @addrs.each do |a|
             # Return the dynamic address assignment if found
-            if a =~ %r{^(dhcp)$}
+            if a =~ %r{^(dhcp|inet6 autoconf)$}
               yield a
-            elsif a =~ %r{^(rtsol|inet6 autoconf)$}
-              kernelversion = Facter.value('kernelversion')
-              if versioncmp(kernelversion, '5.6') <= 0
-                yield 'rtsol'
-              else
-                yield 'inet6 autoconf'
-              end
             else
               begin
                 ip = IPAddress a

--- a/spec/unit/bsd/hostname_if/inet_spec.rb
+++ b/spec/unit/bsd/hostname_if/inet_spec.rb
@@ -16,49 +16,14 @@ describe 'PuppetX::BSD::Hostname_if::Inet' do
   end
 
   describe 'process' do
-    context 'On OpenBSD 5.6' do
-      it 'yields the the dynamic addressing is specified for all AF with rtsol' do
-        a = %w(
-          dhcp
-          rtsol
-        )
-        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
-        expect do |b|
-          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
-        end.to yield_successive_args('dhcp', 'rtsol')
-      end
-      it 'yields the the dynamic addressing is specified for all AF with inet6 autoconf' do
-        a = [
-          'dhcp',
-          'inet6 autoconf'
-        ]
-        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.6')
-        expect do |b|
-          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
-        end.to yield_successive_args('dhcp', 'rtsol')
-      end
-    end
-    context 'On OpenBSD 5.7' do
-      it 'yields the the dynamic addressing is specified for all AF with rtsol' do
-        a = %w(
-          dhcp
-          rtsol
-        )
-        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
-        expect do |b|
-          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
-        end.to yield_successive_args('dhcp', 'inet6 autoconf')
-      end
-      it 'yields the the dynamic addressing is specified for all AF with inet6 autoconf' do
-        a = [
-          'dhcp',
-          'inet6 autoconf'
-        ]
-        expect(Facter).to receive(:value).with('kernelversion').at_least(:once).and_return('5.7')
-        expect do |b|
-          PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
-        end.to yield_successive_args('dhcp', 'inet6 autoconf')
-      end
+    it 'yields the the dynamic addressing is specified for all AF with inet6 autoconf' do
+      a = [
+        'dhcp',
+        'inet6 autoconf'
+      ]
+      expect do |b|
+        PuppetX::BSD::Hostname_if::Inet.new(a).process(&b)
+      end.to yield_successive_args('dhcp', 'inet6 autoconf')
     end
 
     it 'yields multiple addresses when specified' do

--- a/spec/unit/bsd/hostname_if_spec.rb
+++ b/spec/unit/bsd/hostname_if_spec.rb
@@ -50,16 +50,16 @@ describe 'Hostname_if' do
       expect(hif.new(c).content).to match(%r{^dhcp})
     end
 
-    context 'with rtsol given for IPv6' do
-      it 'sets the the dynamic property of the interface is specified for all AF setting inet6 autoconf for rtsol' do
+    context 'with inet6 autoconf given for IPv6' do
+      it 'sets the the dynamic property of the interface is specified for all AF setting inet6 autoconf' do
         c = {
-          raw_values: %w(
-            dhcp
-            rtsol
-          )
+          raw_values: [
+            'dhcp',
+            'inet6 autoconf'
+          ]
         }
-        expect(hif.new(c).content).to match(%r{^dhcp})
-        expect(hif.new(c).content).to match(%r{^rtsol})
+        expect(hif.new(c).content).to match(%r{^dhcp$})
+        expect(hif.new(c).content).to match(%r{^inet6 autoconf$})
       end
     end
 


### PR DESCRIPTION
Here we drop the code that helped the transition to 5.7.  Users are now expected
to use 'inet6 autoconf' in place of 'rtsol'.  This change was part of the
migration to 5.7, which is long since past.  As such, we remove the code here
that worked to ensure compatibility.