### PR TITLE
The switch from returning HostnameIf from Hostname_if lead to errors

### DIFF
--- a/lib/puppet/parser/functions/get_hostname_if_bridge.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_bridge.rb
@@ -9,6 +9,6 @@ module Puppet::Parser::Functions
     c = {}
     c[:interface] = config['interface']
 
-    return HostnameIf::Bridge.new(c).content
+    return Hostname_if::Bridge.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_hostname_if_carp.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_carp.rb
@@ -14,6 +14,6 @@ module Puppet::Parser::Functions
     c[:advbase] = config['advbase'] if config['advbase']
     c[:advskew] = config['advskew'] if config['advskew']
 
-    return HostnameIf::Carp.new(c).content
+    return Hostname_if::Carp.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_hostname_if_pfsync.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_pfsync.rb
@@ -12,6 +12,6 @@ module Puppet::Parser::Functions
     c[:maxupd]   = config['maxupd'] if config['maxupd']
     c[:defer]    = config['defer'] if config['defer']
 
-    return HostnameIf::Pfsync.new(c).content
+    return Hostname_if::Pfsync.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_hostname_if_trunk.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_trunk.rb
@@ -11,6 +11,6 @@ module Puppet::Parser::Functions
     c[:proto]     = config['proto']
     c[:address]   = config['address'] if config['address']
 
-    return HostnameIf::Trunk.new(c).content
+    return Hostname_if::Trunk.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_hostname_if_vlan.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_vlan.rb
@@ -11,6 +11,6 @@ module Puppet::Parser::Functions
     c[:address] = config['address'] if config['address']
     c[:device]  = config['device'] if config['device']
 
-    return HostnameIf::Vlan.new(c).content
+    return Hostname_if::Vlan.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_hostname_if_wifi.rb
+++ b/lib/puppet/parser/functions/get_hostname_if_wifi.rb
@@ -11,6 +11,6 @@ module Puppet::Parser::Functions
     c[:wpa_key]      = config['wpa_key'] if config['wpa_key']
     c[:address]      = config['address'] if config['address']
 
-    return HostnameIf::Wifi.new(c).content
+    return Hostname_if::Wifi.new(c).content
   end
 end

--- a/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
+++ b/lib/puppet/parser/functions/get_openbsd_hostname_if_content.rb
@@ -14,6 +14,6 @@ module Puppet::Parser::Functions
     c[:options]    = config['options'] if config['options']
     c[:mtu]        = config['mtu'] if config['mtu']
 
-    return HostnameIf.new(c).content
+    return Hostname_if.new(c).content
   end
 end


### PR DESCRIPTION
like:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, uninitialized constant Puppet::Parser::Functions::HostnameIf
Did you mean?  Hostname_if (file: /etc/puppetlabs/code/environments/production/modules/bsd/manifests/network/interface/vlan.pp, line: 43, column: 24) (file: /etc/puppetlabs/code/environments/production/modules/profile/manifests/network.pp, line: 53) on node ...

This was seen on OpenBSD with Puppet 5.5.8 to 5.5.16 etc.
in combination with Ruby 2.5.3 to 2.6.3